### PR TITLE
Unified silicon

### DIFF
--- a/config/almostunified/unify.json
+++ b/config/almostunified/unify.json
@@ -8,6 +8,7 @@
         "create",
         "immersiveengineering",
         "occultism",
+        "ae2",
         "ftbic",
         "chemlib",
         "biggerreactors"

--- a/config/cucumber-common.toml
+++ b/config/cucumber-common.toml
@@ -11,6 +11,7 @@
 		"create",
 		"immersiveengineering",
 		"occultism",
+		"ae2",
 		"ftbic",
 		"chemlib",
 		"biggerreactors"

--- a/config/immersiveengineering-common.toml
+++ b/config/immersiveengineering-common.toml
@@ -16,6 +16,7 @@ preferredOres = [
 	"create",
 	"immersiveengineering",
 	"occultism",
+	"ae2",
 	"ftbic",
 	"chemlib",
 	"biggerreactors"

--- a/config/titanium/titanium-tags.toml
+++ b/config/titanium/titanium-tags.toml
@@ -10,6 +10,7 @@
 		"create",
 		"immersiveengineering",
 		"occultism",
+		"ae2",
 		"ftbic",
 		"chemlib",
 		"biggerreactors"

--- a/defaultconfigs/productivebees-server.toml
+++ b/defaultconfigs/productivebees-server.toml
@@ -40,6 +40,7 @@
 		"create",
 		"immersiveengineering",
 		"occultism",
+		"ae2",
 		"ftbic",
 		"chemlib",
 		"biggerreactors"


### PR DESCRIPTION
FTBIC and AE2 have their own variants of silicon but they are tagged with `forge:silicon`. The config changes make sure that essence as well as bees always drop the correct silicon.