### PR TITLE
ATM Star Work 10.28.22

### DIFF
--- a/config/legendarytooltips-common.toml
+++ b/config/legendarytooltips-common.toml
@@ -1,0 +1,109 @@
+
+# Legendary Tooltips Configuration Instructions
+#
+# *** READ THIS FIRST ***
+#
+# By default, this mod does not apply special borders to most items.  It was designed to work well with mod packs where
+# the available selection of items can vary widely, so it is up to the user or mod pack designer to customize as needed.
+# There are many options available for setting up which custom borders (also called frames) apply to which items.  Follow these steps:
+#   1. Decide which items you want to have custom borders, and which borders.  Note that each custom border has a number associated with it (starting at 0).
+#   2. For each custom border you want to use, fill out the associated list in the "definitions" section.  This will be filled out with a list of "selectors",
+#      each of which tell the mod what items have that border.  Please read the information above the definitions section for specifics.
+#   3. Selectors for borders are checked in the order provided in the "priorities" section.  Once a match is found, that border is displayed.
+#      For example, if border 0 had the selector "%Diamond" and border 1 had the selector "diamond_sword", they would both match for diamond swords.
+#      In this case, whichever border number came first in the priority list would be the border that would get drawn in-game.
+#   4. Optionally, border colors associated with custom borders can be set in the "colors" section.  The start color is the color at the top of the tooltip,
+#      and the end color is the bottom, with a smooth transition between.  Please read the information above the color section for specifics.
+[client]
+
+	[client.visual_options]
+		# Whether item names in tooltips should have a line under them separating them from the rest of the tooltip.
+		name_separator = true
+		# If enabled, tooltip border colors will match item rarity colors (except for custom borders).
+		borders_match_rarity = true
+		# If enabled, tooltips will display a drop shadow.
+		tooltip_shadow = true
+		# If enabled, items showing a custom border will have a special shine effect when hovered over.
+		shine_effect = true
+		# If enabled, tooltip titles will be drawn centered.
+		centered_title = true
+		# If enabled, tooltips with custom borders will always be at least wide enough to display all border decorations.
+		enforce_minimum_width = false
+
+	# Entry types:
+	#    Item name - Use item name for vanilla items or include mod name for modded items.  Examples: "minecraft:stick", "iron_ore"
+	#    Tag - $ followed by tag name.  Examples: "$forge:stone", "$planks"
+	#    Mod name - @ followed by mod identifier.  Examples: "@spoiledeggs"
+	#    Rarity - ! followed by item's rarity.  This is ONLY vanilla rarities.  Examples: "!uncommon", "!rare", "!epic"
+	#    Item name color - # followed by color hex code, the hex code must match exactly.  Examples: "#23F632"
+	#    Display name - % followed by any text.  Will match any item with this text in its tooltip display name.  Examples: "%Netherite", "%[Uncommon]"
+	#    Tooltip text - Will match any item with this text anywhere in the tooltip text (besides the name).  Examples: "^Legendary"
+	#    NBT tag - & followed by tag name and optional comparator (=, >, <, or !=) and value, in the format <tag><comparator><value> or just <tag>.  Examples: "&Damage=0", "&Tier>1", "&map!=128", "&Enchantments"
+	[client.definitions]
+		level0_entries = ["!epic", "!rare", "%Allthemodium", "%Vibranium", "%Unobtainium", "%Piglich", "@allthetweaks"]
+		level1_entries = []
+		level2_entries = []
+		level3_entries = []
+		level4_entries = []
+		level5_entries = []
+		level6_entries = []
+		level7_entries = []
+		level8_entries = []
+		level9_entries = []
+		level10_entries = []
+		level11_entries = []
+		level12_entries = []
+		level13_entries = []
+		level14_entries = []
+		level15_entries = []
+		# Enter blacklist selectors here using the same format as above. Any items that match these selectors will NOT show a border.
+		blacklist = []
+
+	# Set border priorities here.  This should be a list of numbers that correspond to border levels, with numbers coming first being higher priority.
+	# Optionally, -1 can be inserted to indicate relative priority of data and api-defined borders.  If you don't know what that means, you don't need to worry about it.
+	[client.priorities]
+		priorities = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+
+	# The colors used for each tooltip, in this order: top border color, bottom border color, top background color, bottom background color.
+	# None of these colors are required, though any colors not specified will be replaced with the default tooltip colors.
+	#
+	# VALID COLOR FORMATS
+	#   Hex color code - A hex color code is preceded by # or 0x and must be quoted.  Supports 3, 4, 6, or 8 digit codes in the formats RGB, ARGB, RRGGBB, AARRGGBB.
+	#     Examples: "#F4C", "0xFEE0", "#40FF2E", "#CC00E2EE"
+	#
+	#   Decimal color code - A decimal color code, which is just a hex color code converted to decimal.  May or may not be quoted.
+	#     Examples: 15614720, "4278251143"
+	#
+	#   Minecraft color name - One of the standard 16 Minecraft color names.  Must be quoted.
+	#     Examples: "red", "dark_purple", "gold"
+	#
+	#   Web color name - One of the standard 140 web/HTML color names or "transparent".  Must be quoted.
+	#     Examples: "chartreuse", "darkorange", "deeppink", "deepskyblue"
+	#
+	#   Modifiers - Colors specified in any of the above formats can be modified by using modifiers.
+	#         Modifiers are specified after any color in the format "<+, -, or =><h, s, v, r, g, b, or a><amount>".
+	#         The letters represent h - hue, s - saturation, v - value, r - red, g - green, b - blue, a - alpha.
+	#         Valid amounts are 0 to 255 for all types except hue, which accepts 0 to 359.
+	#     Examples: "red+h15", "#saddlebrown-v20+s5", "10_aqua_aqua+v15-h5", "#F4C-r15-v10=a40"
+	#
+	#   Animated color - An animated color that fades from one to another in sequence.
+	#         A string in the format "<duration in seconds>_<list of color definitions separated by underscores>".  Must be quoted.
+	#     Examples: "10_black_#7FFF00", "5.5_gold_orange_orangered", "20_red_orange_yellow_green_blue_purple"
+	[client.colors]
+		level0_colors = [-6723294, -10864099, -266991104, -401208832]
+		level1_colors = ["auto", "auto", "auto", "auto"]
+		level2_colors = ["auto", "auto", "auto", "auto"]
+		level3_colors = ["auto", "auto", "auto", "auto"]
+		level4_colors = ["auto", "auto", "auto", "auto"]
+		level5_colors = ["auto", "auto", "auto", "auto"]
+		level6_colors = ["auto", "auto", "auto", "auto"]
+		level7_colors = ["auto", "auto", "auto", "auto"]
+		level8_colors = ["auto", "auto", "auto", "auto"]
+		level9_colors = ["auto", "auto", "auto", "auto"]
+		level10_colors = ["auto", "auto", "auto", "auto"]
+		level11_colors = ["auto", "auto", "auto", "auto"]
+		level12_colors = ["auto", "auto", "auto", "auto"]
+		level13_colors = ["auto", "auto", "auto", "auto"]
+		level14_colors = ["auto", "auto", "auto", "auto"]
+		level15_colors = ["auto", "auto", "auto", "auto"]
+

--- a/kubejs/client_scripts/alloyblock.js
+++ b/kubejs/client_scripts/alloyblock.js
@@ -1,0 +1,3 @@
+JEIEvents.subtypes(event => {
+    event.useNBT("allthemodium:unobtainium_vibranium_alloy_block")
+})

--- a/kubejs/client_scripts/tooltips.js
+++ b/kubejs/client_scripts/tooltips.js
@@ -2,22 +2,33 @@
 
 ItemEvents.tooltip(event => {
 
-	// Temp! Remove me!
+	// Warning for Work in Progress
   [
-    'allthetweaks:atm_star',
     'allthetweaks:dragon_soul',
-    'allthetweaks:dimensional_seed',
     'allthetweaks:withers_compass',
     'allthetweaks:philosophers_fuel',
     'allthetweaks:improbable_probability_device',
     'allthetweaks:pulsating_black_hole',
-    'allthetweaks:oblivion_shard'
+    'allthetweaks:oblivion_shard',
+	'allthetweaks:nexium_emitter'
   ].forEach(item => {
     event.add(item, [
-      Text.of('Work in Progress').red(),
-      Text.of('This is not yet meant to be craftable').red()
+      Text.of('Work in Progress').red()
     ])
   })
+  
+	// Warning for Not Yet Craftable
+    event.add(
+	[
+	  'allthetweaks:atm_star',
+	  'allthetweaks:dimensional_seed'
+	], 
+	  [
+	  Text.of('Work in Progress').red(),
+	  Text.of('This is not yet meant to be craftable').red()
+	  ])
+  
+    
 
 	// Re-add Chemlib info to unified materials
 	let chemlibTooltips = JsonIO.read('kubejs/client_scripts/chemlibCompat.json')

--- a/kubejs/server_scripts/modpack/atm_alloys.js
+++ b/kubejs/server_scripts/modpack/atm_alloys.js
@@ -5,15 +5,17 @@ ServerEvents.recipes(event => {
     type: 'powah:energizing',
     ingredients: [
       Ingredient.of('allthemodium:allthemodium_ingot').toJson(),
-      Ingredient.of('allthemodium:vibranium_ingot').toJson()
+	  Ingredient.of('allthemodium:piglich_heart').toJson(),
+	  Ingredient.of('allthemodium:vibranium_ingot').toJson()
+	  
     ],
-    energy: '100000000',
-    result: Item.of('allthemodium:vibranium_allthemodium_alloy_ingot').toJson()
+    energy: '1000000000',
+	result: Item.of('allthemodium:vibranium_allthemodium_alloy_ingot').toJson()
   }).id(`kubejs:energizing/allthemodium:vibranium_allthemodium_alloy_ingot`)
-  ,
   
   
  // ATM-Vibranium Block
+ /*
   event.custom({
     type: 'powah:energizing',
     ingredients: [
@@ -23,22 +25,23 @@ ServerEvents.recipes(event => {
     energy: '1000000000',
     result: Item.of('allthemodium:vibranium_allthemodium_alloy_block').toJson()
   }).id(`kubejs:energizing/allthemodium:vibranium_allthemodium_alloy_block`)
-  ,
-
+*/
 
  // ATM-Unobtainium Ingot
   event.custom({
     type: 'powah:energizing',
     ingredients: [
       Ingredient.of('allthemodium:allthemodium_ingot').toJson(),
-      Ingredient.of('allthemodium:unobtainium_ingot').toJson()
+      Ingredient.of('allthemodium:piglich_heart').toJson(),
+	  Ingredient.of('allthemodium:unobtainium_ingot').toJson()
+	  
     ],
-    energy: '250000000',
+    energy: '1000000000',
     result: Item.of('allthemodium:unobtainium_allthemodium_alloy_ingot').toJson()
   }).id(`kubejs:energizing/allthemodium:unobtainium_allthemodium_alloy_ingot`)
-  ,
   
 // ATM-Unobtainium Block
+/*
   event.custom({
     type: 'powah:energizing',
     ingredients: [
@@ -48,23 +51,55 @@ ServerEvents.recipes(event => {
     energy: '2500000000',
     result: Item.of('allthemodium:unobtainium_allthemodium_alloy_block').toJson()
   }).id(`kubejs:energizing/allthemodium:unobtainium_allthemodium_alloy_block`)
-  ,
+  */
   
   
- // Vibranium-Unobtainium Ingot
+ // Unobtainium-Vibranium Ingot
   event.custom({
     type: 'powah:energizing',
     ingredients: [
       Ingredient.of('allthemodium:vibranium_ingot').toJson(),
-      Ingredient.of('allthemodium:unobtainium_ingot').toJson()
+      Ingredient.of('allthemodium:piglich_heart').toJson(),
+	  Ingredient.of('allthemodium:unobtainium_ingot').toJson()
+	  
     ],
-    energy: '125000000',
+    energy: '1000000000',
     result: Item.of('allthemodium:unobtainium_vibranium_alloy_ingot').toJson()
   }).id(`kubejs:energizing/allthemodium:unobtainium_vibranium_alloy_ingot`)
-  ,
   
+// Unobtainium-Vibranium Awakened Block
+  event.custom({
+  "type": "mysticalagriculture:awakening",
+  "essences": {
+    "air": 40,
+    "earth": 40,
+    "water": 40,
+    "fire": 40
+  },
+  "input": {
+    "item": "allthemodium:unobtainium_vibranium_alloy_block"
+  },
+  "ingredients": [
+    {
+      "item": "allthemodium:vibranium_block"
+    },
+    {
+      "item": "allthemodium:unobtainium_block"
+    },
+    {
+      "item": "allthemodium:vibranium_block"
+    },
+    {
+      "item": "allthemodium:unobtainium_block"
+    }
+  ],
+  "result":  
+	Item.of('allthemodium:unobtainium_vibranium_alloy_block', "{HideFlags:1,display:{Name:'[{\"text\":\"Awakened Unobtainium-Vibranium Alloy Block\",\"italic\":false}]'}}").enchant('unbreaking', 1).toJson()
+
+}).id(`kubejs:awakening/awakened_unobtainium_vibranium_alloy_block`)
   
-// Vibranium-Unobtainium Block
+// Unobtainium-Vibranium Block
+/*
   event.custom({
     type: 'powah:energizing',
     ingredients: [
@@ -74,5 +109,7 @@ ServerEvents.recipes(event => {
     energy: '1250000000',
     result: Item.of('allthemodium:unobtainium_vibranium_alloy_block').toJson()
   }).id(`kubejs:energizing/allthemodium:unobtainium_vibranium_alloy_block`)
+  
+*/
   
 })

--- a/kubejs/server_scripts/modpack/atm_star.js
+++ b/kubejs/server_scripts/modpack/atm_star.js
@@ -6,7 +6,7 @@ ServerEvents.recipes(event => {
       '   AJA   ',
       'AAAJFJAAA',
       'AJJCDEJJA',
-      ' ANBIHMA ',
+      ' AMBIHMA ',
       '  AKGLA  ',
       ' AJJAJJA ',
       'AJJA AJJA',
@@ -25,8 +25,7 @@ ServerEvents.recipes(event => {
       J: Ingredient.of('minecraft:bedrock').toJson(),
       K: Ingredient.of('allthetweaks:philosophers_fuel').toJson(),
       L: Ingredient.of('mysticalagradditions:creative_essence').toJson(),
-      M: Ingredient.of('minecraft:bedrock').toJson(),
-      N: Ingredient.of('minecraft:bedrock').toJson()
+      M: Item.of('allthemodium:unobtainium_vibranium_alloy_block', "{HideFlags:1,display:{Name:'[{\"text\":\"Awakened Unobtainium-Vibranium Alloy Block\",\"italic\":false}]'}}").enchant('unbreaking', 1).strongNBT().toJson()
     },
     result: Ingredient.of('allthetweaks:atm_star').toJson(),
     acceptMirrored: false

--- a/kubejs/server_scripts/modpack/att_items.js
+++ b/kubejs/server_scripts/modpack/att_items.js
@@ -63,7 +63,7 @@ ServerEvents.recipes(event => {
     C: ['extradisks:1048576k_storage_part', 'extradisks:1048576k_fluid_storage_part', 'megacells:cell_component_256m'],
     D: 'advgenerators:power_capacitor_tier3',
 	E: 'rftoolsutility:flight_module',
-    F: 'powah:battery_nitro',
+    F: Item.of('powah:battery_nitro', '{powah_tile_data:{energy_stored_main_energy:2000000000L}}').strongNBT(),
     G: 'ftbic:nuke'
   }).id('kubejs:allthetweaks/improbable_probability_device')
 
@@ -105,7 +105,7 @@ ServerEvents.recipes(event => {
   // Oblivion Shard
   // Alfred's Proposal
   event.shaped('allthetweaks:oblivion_shard', [' AB', 'ACA', 'BA '], {
-    A: 'allthemodium:unobtainium_block',
+    A: 'spirit:soul_steel_block',
     C: 'naturesaura:end_flower',
     B: 'naturesaura:chunk_loader'
   }).id('kubejs:allthetweaks/oblivion_shard')

--- a/kubejs/server_scripts/modpack/mini_twilight_portal.js
+++ b/kubejs/server_scripts/modpack/mini_twilight_portal.js
@@ -19,7 +19,7 @@ ServerEvents.recipes(event => {
       "item": "twilightforest:knightmetal_block"
     },
     {
-      "item": "twilightforest:twilightforest:steeleaf_block"
+      "item": "twilightforest:steeleaf_block"
     },
     {
       "item": "twilightforest:carminite_block"
@@ -28,5 +28,5 @@ ServerEvents.recipes(event => {
   "result": {
     "item": "twilightforest:twilight_portal_miniature_structure"
 	}
-	})
+	}).id(`kubejs:awakening/twilight_portal_miniature_structure`)
 })


### PR DESCRIPTION
- Added Legendary Tooltips config to include all AlltheTweaks items and several Allthemodium Items
- Added client script for JEI for one of the items needed for the star (Awakened Unobtainium-Vibranium Alloy Block)
- Adjusted JEI Tooltips to reflect items that can be crafted, all are works in progress
- Added kubejs for making ATM alloy ingots via Powah Energizing. Also has placeholders for Block recipes for future crafting ideas
- Created Custom Recipe for "Miniature Twilight Portal Structure" via Mystical Ag's "Awakening" recipe, used for crafting the Philosopher's Fuel (replaces Carmonite Block)
- Adjusted recipes of all items needed for the star except for the Dimensional Seed
- Adjusted the ATM Star recipe to include a new item, the Awakened Unobtainium-Vibranium Block (replaces Botania high tier runes from ATM7)