### PR TITLE
Remove "bee" suffix from aluminium comb quest subtitle

### DIFF
--- a/config/ftbquests/quests/chapters/productive_bees.snbt
+++ b/config/ftbquests/quests/chapters/productive_bees.snbt
@@ -726,7 +726,7 @@
 			icon: "alltheores:aluminum_ingot"
 			x: -1.0d
 			y: 11.5d
-			subtitle: "Crystalline + Ashy Mining Bee"
+			subtitle: "Crystalline + Ashy Mining"
 			description: [""]
 			hide_dependency_lines: true
 			dependencies: ["17419401147B5C02"]


### PR DESCRIPTION
The other comb quests mention them as "ashy mining" without the "bee" suffix, this was the odd one out.