### PR TITLE
Fix #405: Silicon from wrong mod in quest reward table

### DIFF
--- a/config/ftbquests/quests/reward_tables/refined_storage_base_materials.snbt
+++ b/config/ftbquests/quests/reward_tables/refined_storage_base_materials.snbt
@@ -4,7 +4,7 @@
 	title: "Refined Storage Base Materials"
 	loot_size: 1
 	rewards: [
-		{ item: "refinedstorage:silicon", count: 5 }
+		{ item: "ae2:silicon", count: 5 }
 		{ item: "refinedstorage:quartz_enriched_iron", count: 5, weight: 2 }
 		{ item: "refinedstorage:machine_casing" }
 	]


### PR DESCRIPTION
The unification process replaces Refined Storage silicon with AE2 silicon; this should also be reflected in the quest reward tables.