### PR TITLE
Fix #329: Conflict between Sturdy Stone and Cobblestone Block 1x

### DIFF
--- a/kubejs/server_scripts/mods/quark/quark.js
+++ b/kubejs/server_scripts/mods/quark/quark.js
@@ -1,0 +1,7 @@
+ServerEvents.recipes(event => {
+  // Fix Sturdy Stone conflict
+  event.shaped('quark:sturdy_stone', [' A ', 'ABA', ' A '], {
+    A: '#forge:nuggets/iron',
+    B: 'allthecompressed:cobblestone_block_1x'
+  }).id('quark:building/crafting/sturdy_stone')
+})


### PR DESCRIPTION
This fixes a recipe conflict that caused compressing cobblestone to output sturdy stone from Quark instead of the expected Cobblestone Block 1x from ATC. Sturdy Stone remains craftable at the cost of said Cobblestone Block 1x plus some iron.

Recipe preview:
![image](https://user-images.githubusercontent.com/37945304/207521399-c123794c-9bfd-4f43-8e35-d08f7a226d04.png)

Fixes #329 and fixes #419