### PR TITLE
Updated "montior_render" to VBO

### DIFF
--- a/config/computercraft-client.toml
+++ b/config/computercraft-client.toml
@@ -2,7 +2,7 @@
 #monitors have performance issues, you may wish to experiment with alternative
 #renderers.
 #Allowed Values: BEST, TBO, VBO
-monitor_renderer = "TBO"
+monitor_renderer = "VBO"
 #The maximum distance monitors will render at. This defaults to the standard tile
 #entity limit, but may be extended if you wish to build larger monitors.
 #Range: 16 ~ 1024


### PR DESCRIPTION
Screens and Advanced Screems render Transparent in conjunction with shaders. This is a known bug of the TBO Rendering system of Computer Craft. Changing this Setting from TBO (default) to VBO is a bit slower (regarding ComputerCraft), but is compatible with all bundled Shaders.

Before the Fix:
[Imgur](https://imgur.com/wfwep0c)

After the Fix:
[Imgur](https://imgur.com/3Dhl75A)

Source: https://github.com/cc-tweaked/CC-Tweaked/wiki/Monitor-renderers