### PR TITLE
misc: Quest updates in tips&tricks and IF

### DIFF
--- a/config/ftbquests/quests/chapters/industrial_foregoing.snbt
+++ b/config/ftbquests/quests/chapters/industrial_foregoing.snbt
@@ -58,6 +58,12 @@
 			x: 1.5d
 			y: 0.0d
 			shape: "rsquare"
+			subtitle: "Doesn't look like much."
+			description: [
+				"This is the base for simple machines in Industrial Foregoing."
+				""
+				"Crafting extras is never a bad idea."
+			]
 			dependencies: ["55820773BDD5319D"]
 			id: "6E616DB197387C86"
 			tasks: [{
@@ -92,6 +98,14 @@
 		{
 			x: 5.0d
 			y: 0.0d
+			subtitle: "Get some material for the ducks."
+			description: [
+				"&2Latex Processing Unit&r turns liquid &2Latex&r into &2Dry Rubber&r pieces. These can then be used to create &2Plastic&r."
+				""
+				"Plastic will be needed for pretty much every machine or item from Industrial Foregoing."
+				""
+				"A single &2Latex Processing Unit&r can usually ingest Latex from several &2Fluid Extractors&r."
+			]
 			dependencies: ["321FA7348E532F4E"]
 			id: "6FF04DD735346BED"
 			tasks: [{
@@ -155,36 +169,36 @@
 					id: "mekanism:basic_fluid_tank"
 					Count: 1b
 					tag: {
-						display: {
-							Lore: ["\"(+NBT)\""]
-						}
 						mekData: {
 							securityMode: 0
 							Items: [ ]
 							FluidTanks: [{
 								Tank: 0b
 								stored: {
-									Amount: 14000
 									FluidName: "industrialforegoing:latex"
+									Amount: 14000
 								}
 							}]
 						}
 						BlockEntityTag: {
-							ForgeCaps: { }
-							activeState: 0b
-							id: "mekanism:basic_fluid_tank"
-							redstone: 0b
-							Items: [ ]
-							updateDelay: 0
-							editMode: 0
 							currentRedstone: 15
 							FluidTanks: [{
 								Tank: 0b
 								stored: {
-									Amount: 14000
 									FluidName: "industrialforegoing:latex"
+									Amount: 14000
 								}
 							}]
+							updateDelay: 0
+							activeState: 0b
+							editMode: 0
+							ForgeCaps: { }
+							Items: [ ]
+							id: "mekanism:basic_fluid_tank"
+							redstone: 0b
+						}
+						display: {
+							Lore: ["\"(+NBT)\""]
 						}
 					}
 				}
@@ -309,8 +323,8 @@
 								FluidTanks: [{
 									Tank: 0b
 									stored: {
-										Amount: 14000
 										FluidName: "industrialforegoing:pink_slime"
+										Amount: 14000
 									}
 								}]
 							}
@@ -330,8 +344,8 @@
 								FluidTanks: [{
 									Tank: 0b
 									stored: {
-										Amount: 14000
 										FluidName: "industrialforegoing:meat"
+										Amount: 14000
 									}
 								}]
 							}
@@ -841,36 +855,36 @@
 					id: "mekanism:basic_fluid_tank"
 					Count: 1b
 					tag: {
-						display: {
-							Lore: ["\"(+NBT)\""]
-						}
 						mekData: {
 							securityMode: 0
 							Items: [ ]
 							FluidTanks: [{
 								Tank: 0b
 								stored: {
-									Amount: 14000
 									FluidName: "industrialforegoing:ether_gas"
+									Amount: 14000
 								}
 							}]
 						}
 						BlockEntityTag: {
-							ForgeCaps: { }
-							activeState: 0b
-							id: "mekanism:basic_fluid_tank"
-							redstone: 0b
-							Items: [ ]
-							updateDelay: 0
-							editMode: 0
 							currentRedstone: 15
 							FluidTanks: [{
 								Tank: 0b
 								stored: {
-									Amount: 14000
 									FluidName: "industrialforegoing:ether_gas"
+									Amount: 14000
 								}
 							}]
+							updateDelay: 0
+							activeState: 0b
+							editMode: 0
+							ForgeCaps: { }
+							Items: [ ]
+							id: "mekanism:basic_fluid_tank"
+							redstone: 0b
+						}
+						display: {
+							Lore: ["\"(+NBT)\""]
 						}
 					}
 				}
@@ -1218,17 +1232,17 @@
 						id: "industrialforegoing:infinity_trident"
 						Count: 1b
 						tag: {
-							Riptide: 0
 							CanCharge: 1b
-							Fluid: {
-								Amount: 0
-								FluidName: "biofuel"
-							}
+							Riptide: 0
 							Channeling: 0b
-							Selected: "POOR"
-							Special: 0b
-							Loyalty: 0
 							Energy: 0L
+							Fluid: {
+								FluidName: "biofuel"
+								Amount: 0
+							}
+							Special: 0b
+							Selected: "POOR"
+							Loyalty: 0
 						}
 					}
 				}
@@ -1239,14 +1253,14 @@
 						id: "industrialforegoing:infinity_drill"
 						Count: 1b
 						tag: {
-							Energy: 0L
 							CanCharge: 1b
 							Special: 0b
-							Fluid: {
-								Amount: 0
-								FluidName: "biofuel"
-							}
 							Selected: "POOR"
+							Energy: 0L
+							Fluid: {
+								FluidName: "biofuel"
+								Amount: 0
+							}
 						}
 					}
 				}
@@ -1257,14 +1271,14 @@
 						id: "industrialforegoing:infinity_saw"
 						Count: 1b
 						tag: {
-							Energy: 0L
 							CanCharge: 1b
 							Special: 0b
-							Fluid: {
-								Amount: 0
-								FluidName: "biofuel"
-							}
 							Selected: "POOR"
+							Energy: 0L
+							Fluid: {
+								FluidName: "biofuel"
+								Amount: 0
+							}
 						}
 					}
 				}
@@ -1275,13 +1289,13 @@
 						id: "industrialforegoing:infinity_hammer"
 						Count: 1b
 						tag: {
-							Energy: 0L
 							CanCharge: 1b
-							Special: 0b
+							Energy: 0L
 							Fluid: {
-								Amount: 0
 								FluidName: "biofuel"
+								Amount: 0
 							}
+							Special: 0b
 							Selected: "POOR"
 							Beheading: 0
 						}
@@ -1294,10 +1308,10 @@
 						id: "industrialforegoing:infinity_backpack"
 						Count: 1b
 						tag: {
-							Energy: 0L
 							CanCharge: 1b
 							Special: 0b
 							Selected: "POOR"
+							Energy: 0L
 						}
 					}
 				}
@@ -1385,4 +1399,5 @@
 			}]
 		}
 	]
+	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/tips_and_tricks.snbt
+++ b/config/ftbquests/quests/chapters/tips_and_tricks.snbt
@@ -188,11 +188,11 @@
 						Count: 1b
 						tag: {
 							state: {
-								data: { }
+								serializer: "buildinggadgets:dummy_serializer"
 								state: {
 									Name: "minecraft:air"
 								}
-								serializer: "buildinggadgets:dummy_serializer"
+								data: { }
 							}
 						}
 					}
@@ -205,11 +205,11 @@
 						Count: 1b
 						tag: {
 							state: {
-								data: { }
+								serializer: "buildinggadgets:dummy_serializer"
 								state: {
 									Name: "minecraft:air"
 								}
-								serializer: "buildinggadgets:dummy_serializer"
+								data: { }
 							}
 						}
 					}
@@ -221,13 +221,13 @@
 						id: "buildinggadgets:gadget_copy_paste"
 						Count: 1b
 						tag: {
+							mode: 0b
 							template_id: [I;
 								1687424916
 								-1474150034
 								-1591711937
 								1045183693
 							]
-							mode: 0b
 						}
 					}
 				}
@@ -293,6 +293,13 @@
 				"73F91BF3D424B269"
 				"0F75D7B9F4FF2459"
 				"2A2E3D020B1F5126"
+				"7732A4AE58D1315E"
+				"3FC002E5A6C08DCC"
+				"70B6C9409AE69284"
+				"02BC692836789920"
+				"5D18D7EFC37DB81E"
+				"6E765D09EA7F6462"
+				"59E3C914DBF957D5"
 			]
 			id: "0F8F37D7E12078F5"
 			tasks: [{
@@ -358,6 +365,11 @@
 			x: -2.0d
 			y: 5.0d
 			subtitle: "A Simple Magnet!"
+			description: [
+				"Requires no power."
+				"Do not forget to activate it using right click after you craft it, otherwise it won't work."
+				"You can wear it in a bauble slot."
+			]
 			id: "3FC002E5A6C08DCC"
 			tasks: [{
 				id: "4112D6272EC400DE"
@@ -438,5 +450,66 @@
 				xp: 100
 			}]
 		}
+		{
+			x: -1.5d
+			y: 6.5d
+			subtitle: "Jump higher, run faster!"
+			description: [
+				"This ring will allow you to run faster, jump higher and also gives step assist. It is very handy in early game, where you need to move around a lot."
+				""
+				"It will require the &2Blood Infuser&r, some blood in &2Blood Extractors&r and &2Dark Gems&r which you may find underground."
+				""
+				"The use of it does not require any type of power, mana or energy - it just works!"
+			]
+			id: "6E765D09EA7F6462"
+			tasks: [{
+				id: "7D6452C5E6C01374"
+				type: "item"
+				item: "evilcraft:effortless_ring"
+			}]
+			rewards: [{
+				id: "63655CE3EE6C6E59"
+				type: "xp"
+				xp: 10
+			}]
+		}
+		{
+			x: 3.5d
+			y: 6.5d
+			subtitle: "Tired of always carrying torches?"
+			description: [
+				"You can upgrade your Silent Gear tools to place phantom lights when used."
+				""
+				"Craft a &2Tip Upgrade Blueprint&f, and use it to make a &2Glowstone Tip Upgrade&f."
+				""
+				"Right clicking with the tool will now place lights. Note that this costs a small amount of durability."
+			]
+			id: "59E3C914DBF957D5"
+			tasks: [{
+				id: "24C7CB7D051209E1"
+				type: "item"
+				item: {
+					id: "silentgear:tip"
+					Count: 1b
+					tag: {
+						Materials: [{
+							Item: {
+								id: "minecraft:glowstone_dust"
+								Count: 1b
+							}
+							ID: "silentgear:glowstone"
+						}]
+					}
+				}
+				match_nbt: true
+				weak_nbt_match: true
+			}]
+			rewards: [{
+				id: "11540189BBC70AD7"
+				type: "xp"
+				xp: 10
+			}]
+		}
 	]
+	quest_links: [ ]
 }


### PR DESCRIPTION
After consulting with @alfredggttv here are some initial quest improvements.

Posting screenshots of relevant changes (rest is just some line re-ordering).

Added two quests to the tips/tricks chapter, and fixed the middle quest to really require all of the tips&tricks quests (it did not before):
<img width="528" alt="CleanShot 2023-01-05 at 04 56 08@2x" src="https://user-images.githubusercontent.com/1835434/210693900-24679f50-f71f-4fcd-ac27-acb5e12c5bc1.png">

Here are the two new quests in the questline.
<img width="456" alt="CleanShot 2023-01-05 at 04 56 05@2x" src="https://user-images.githubusercontent.com/1835434/210693971-33fba808-be4b-49d8-92c2-5e2502bebc29.png">
<img width="496" alt="CleanShot 2023-01-05 at 04 55 56@2x" src="https://user-images.githubusercontent.com/1835434/210693975-3e4f256b-9c80-457c-9eb5-01bc14e0b8ea.png">

As a side hustle I updated the texts of two quests in the IF chapter:
<img width="426" alt="CleanShot 2023-01-05 at 05 11 10@2x" src="https://user-images.githubusercontent.com/1835434/210694043-d4b01081-2382-4acf-a32b-d479fcee44c8.png">
<img width="422" alt="CleanShot 2023-01-05 at 05 08 53@2x" src="https://user-images.githubusercontent.com/1835434/210694048-97ea9cbc-2470-482e-8000-709a5e63d199.png">

