### PR TITLE
Quest Update 4-18-23 | Added Creative, Thermal, and Mystical Ag Quest Rework

### DIFF
--- a/config/ftbquests/quests/chapters/allthemodium.snbt
+++ b/config/ftbquests/quests/chapters/allthemodium.snbt
@@ -3,7 +3,7 @@
 	group: ""
 	order_index: 1
 	filename: "allthemodium"
-	title: "Allthemodium"
+	title: "&eAllthemodium"
 	icon: "allthemodium:allthemodium_ingot"
 	default_quest_shape: ""
 	default_hide_dependency_lines: true
@@ -58,7 +58,7 @@
 				""
 				"Find this rare ore in the Nether's Warped Forests and Crimson Forests between Y100 to Y123. "
 				""
-				"The best place to find this ore is in any biome in the Other, between Y0 and Y20."
+				"You can also find this ore is in any biome in the Other, between Y0 and Y20."
 			]
 			hide_dependency_lines: false
 			dependencies: ["5BDBE666E604FCAC"]
@@ -98,8 +98,6 @@
 				"An extremely rare ore that can only be found after defeating the Ender Dragon."
 				""
 				"You can find this obtainable ore in the End Highlands biome."
-				""
-				"Note: It is rare."
 			]
 			hide_dependency_lines: false
 			dependencies: ["2DF64CB9298E91EA"]
@@ -122,17 +120,17 @@
 					xp: 100
 				}
 				{
-					id: "10C180EFA4159779"
+					id: "0E328B594DAC6713"
 					type: "random"
 					exclude_from_claim_all: true
-					table_id: 7025454341029952768L
+					table_id: 5564196992594175882L
 				}
 			]
 		}
 		{
-			x: -1.5d
-			y: 4.0d
-			shape: "square"
+			x: -2.0d
+			y: 3.5d
+			shape: "diamond"
 			description: [
 				"Extremely fast furnace."
 				""
@@ -140,6 +138,7 @@
 			]
 			hide_dependency_lines: false
 			dependencies: ["71A43C89EB13E9A0"]
+			hide: true
 			id: "2CC97CF32D9C017B"
 			tasks: [{
 				id: "07FF0DC32B705DCC"
@@ -155,7 +154,7 @@
 		}
 		{
 			x: -1.5d
-			y: 2.0d
+			y: 2.5d
 			shape: "gear"
 			description: [""]
 			hide_dependency_lines: false
@@ -167,29 +166,15 @@
 				type: "item"
 				item: "allthemodium:allthemodium_ingot"
 			}]
-			rewards: [
-				{
-					id: "5020DF4E727436E1"
-					type: "item"
-					item: "allthemodium:raw_allthemodium"
-					random_bonus: 2
-				}
-				{
-					id: "60BFD3F6B6CAE723"
-					type: "xp"
-					xp: 100
-				}
-				{
-					id: "4F440948C38AE875"
-					type: "random"
-					exclude_from_claim_all: true
-					table_id: 487623848494439020L
-				}
-			]
+			rewards: [{
+				id: "60BFD3F6B6CAE723"
+				type: "xp"
+				xp: 100
+			}]
 		}
 		{
 			x: 0.0d
-			y: 2.5d
+			y: 3.0d
 			shape: "gear"
 			description: [""]
 			hide_dependency_lines: false
@@ -200,30 +185,16 @@
 				type: "item"
 				item: "allthemodium:vibranium_ingot"
 			}]
-			rewards: [
-				{
-					id: "10CF2B304F78BC79"
-					type: "item"
-					item: "allthemodium:raw_vibranium"
-					random_bonus: 2
-				}
-				{
-					id: "2EFC640150403D08"
-					type: "xp"
-					xp: 100
-				}
-				{
-					id: "447A71C76668619D"
-					type: "random"
-					exclude_from_claim_all: true
-					table_id: 487623848494439020L
-				}
-			]
+			rewards: [{
+				id: "2EFC640150403D08"
+				type: "xp"
+				xp: 100
+			}]
 		}
 		{
-			x: 0.0d
+			x: -0.5d
 			y: 4.0d
-			shape: "square"
+			shape: "diamond"
 			description: [
 				"How fast can this possibly get!?"
 				""
@@ -231,6 +202,7 @@
 			]
 			hide_dependency_lines: false
 			dependencies: ["61FDABF2C7CC1F9D"]
+			hide: true
 			id: "5CA0BA27F9C537B2"
 			tasks: [{
 				id: "0B2932972CD2E73E"
@@ -245,9 +217,9 @@
 			}]
 		}
 		{
-			x: 1.5d
-			y: 4.0d
-			shape: "square"
+			x: 1.0d
+			y: 3.5d
+			shape: "diamond"
 			description: [
 				"Now you are just showing off."
 				""
@@ -255,6 +227,7 @@
 			]
 			hide_dependency_lines: false
 			dependencies: ["44760B819EB3CA68"]
+			hide: true
 			id: "1AFDB3AE73E72A33"
 			tasks: [{
 				id: "579B48ABB0CBD18A"
@@ -277,10 +250,11 @@
 		}
 		{
 			x: -3.5d
-			y: 5.0d
+			y: 6.0d
 			shape: "square"
 			hide_dependency_lines: true
 			dependencies: ["71A43C89EB13E9A0"]
+			hide: true
 			id: "1BF186347C4683B3"
 			tasks: [{
 				id: "5CCD462442A9CBC9"
@@ -294,11 +268,6 @@
 				}
 			}]
 			rewards: [
-				{
-					id: "4A4EE4EFBC58BDB2"
-					type: "item"
-					item: "allthemodium:raw_allthemodium"
-				}
 				{
 					id: "7CEDAB343096A16E"
 					type: "xp"
@@ -314,10 +283,11 @@
 		}
 		{
 			x: -3.5d
-			y: 4.0d
+			y: 5.0d
 			shape: "square"
 			hide_dependency_lines: true
 			dependencies: ["71A43C89EB13E9A0"]
+			hide: true
 			id: "26296F815ACC04BE"
 			tasks: [{
 				id: "7CE4D8C55D2A92A8"
@@ -331,11 +301,6 @@
 				}
 			}]
 			rewards: [
-				{
-					id: "13231543FF20CB14"
-					type: "item"
-					item: "allthemodium:raw_allthemodium"
-				}
 				{
 					id: "7B6B2810FB076635"
 					type: "xp"
@@ -351,9 +316,10 @@
 		}
 		{
 			x: -3.5d
-			y: 3.0d
+			y: 4.0d
 			shape: "square"
 			dependencies: ["71A43C89EB13E9A0"]
+			hide: true
 			id: "4C7718982E78D7A2"
 			tasks: [{
 				id: "4979179C2D56C137"
@@ -367,11 +333,6 @@
 				}
 			}]
 			rewards: [
-				{
-					id: "7EA6871E90A242E9"
-					type: "item"
-					item: "allthemodium:raw_allthemodium"
-				}
 				{
 					id: "727160FABA1B8DF6"
 					type: "xp"
@@ -387,9 +348,10 @@
 		}
 		{
 			x: -3.5d
-			y: 2.0d
+			y: 3.0d
 			shape: "square"
 			dependencies: ["71A43C89EB13E9A0"]
+			hide: true
 			dependency_requirement: "one_completed"
 			id: "29637BD992599915"
 			tasks: [{
@@ -405,11 +367,6 @@
 			}]
 			rewards: [
 				{
-					id: "2290371EE7E604DA"
-					type: "item"
-					item: "allthemodium:raw_allthemodium"
-				}
-				{
 					id: "28AB1CC409C9BADB"
 					type: "xp"
 					xp: 100
@@ -423,6 +380,14 @@
 			]
 		}
 		{
+			title: "Intro to Allthemodium!"
+			icon: {
+				id: "patchouli:guide_book"
+				Count: 1b
+				tag: {
+					"patchouli:book": "allthemodium:allthemodium"
+				}
+			}
 			x: 0.0d
 			y: -1.0d
 			shape: "rsquare"
@@ -436,14 +401,7 @@
 			tasks: [{
 				id: "159872B988A173AA"
 				type: "dimension"
-				title: "Intro to Allthemodium!"
-				icon: {
-					id: "patchouli:guide_book"
-					Count: 1b
-					tag: {
-						"patchouli:book": "allthemodium:allthemodium"
-					}
-				}
+				title: "Exist!"
 				dimension: "minecraft:overworld"
 			}]
 			rewards: [
@@ -467,7 +425,7 @@
 		}
 		{
 			x: 1.5d
-			y: 2.0d
+			y: 2.5d
 			shape: "gear"
 			hide_dependency_lines: false
 			dependencies: ["4F6E6AF1D9E74CB7"]
@@ -477,32 +435,19 @@
 				type: "item"
 				item: "allthemodium:unobtainium_ingot"
 			}]
-			rewards: [
-				{
-					id: "194CC53948B7BAE9"
-					type: "item"
-					item: "allthemodium:raw_unobtainium"
-					random_bonus: 1
-				}
-				{
-					id: "339251D95518BB97"
-					type: "xp"
-					xp: 100
-				}
-				{
-					id: "15AD0AE0B1117299"
-					type: "random"
-					exclude_from_claim_all: true
-					table_id: 487623848494439020L
-				}
-			]
+			rewards: [{
+				id: "339251D95518BB97"
+				type: "xp"
+				xp: 100
+			}]
 		}
 		{
 			x: 3.5d
-			y: 6.0d
+			y: 7.0d
 			shape: "heart"
 			hide_dependency_lines: true
 			dependencies: ["71A43C89EB13E9A0"]
+			hide: true
 			id: "7F3B96033AB7A21E"
 			tasks: [{
 				id: "6C79D005D95BAB61"
@@ -511,25 +456,25 @@
 			}]
 			rewards: [
 				{
-					id: "18230E6F7C7E1270"
-					type: "item"
-					item: "allthemodium:allthemodium_nugget"
-					count: 3
-					random_bonus: 3
-				}
-				{
 					id: "51777CA9A13AAD35"
 					type: "xp"
 					xp: 100
+				}
+				{
+					id: "2FD4422A73C37850"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4196188979167302596L
 				}
 			]
 		}
 		{
 			x: -3.5d
-			y: 6.0d
+			y: 7.0d
 			shape: "heart"
 			hide_dependency_lines: true
 			dependencies: ["71A43C89EB13E9A0"]
+			hide: true
 			id: "15D56588634665FA"
 			tasks: [{
 				id: "32629A7C461C48F7"
@@ -538,24 +483,25 @@
 			}]
 			rewards: [
 				{
-					id: "3AFF1B34274BE118"
-					type: "item"
-					item: "allthemodium:allthemodium_nugget"
-					count: 3
-					random_bonus: 3
-				}
-				{
 					id: "40F8666A439FDC16"
 					type: "xp"
 					xp: 100
+				}
+				{
+					id: "0186D353D38596DC"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4196188979167302596L
 				}
 			]
 		}
 		{
 			x: 3.5d
-			y: 2.0d
+			y: 3.0d
 			shape: "square"
-			dependencies: ["5BDBE666E604FCAC"]
+			hide_dependency_lines: true
+			dependencies: ["71A43C89EB13E9A0"]
+			hide: true
 			id: "30E6C6825D78B5F1"
 			tasks: [{
 				id: "448F535D62D9FDC7"
@@ -563,12 +509,6 @@
 				item: "allthemodium:allthemodium_sword"
 			}]
 			rewards: [
-				{
-					id: "45FE78A21B454ACE"
-					type: "item"
-					item: "allthemodium:raw_allthemodium"
-					random_bonus: 2
-				}
 				{
 					id: "407C0224BB0CF2C7"
 					type: "xp"
@@ -584,9 +524,10 @@
 		}
 		{
 			x: 3.5d
-			y: 3.0d
+			y: 4.0d
 			shape: "square"
-			dependencies: ["5BDBE666E604FCAC"]
+			dependencies: ["71A43C89EB13E9A0"]
+			hide: true
 			id: "061784A9E41AB60B"
 			tasks: [{
 				id: "04FDDE47BDA0BA81"
@@ -594,12 +535,6 @@
 				item: "allthemodium:allthemodium_pickaxe"
 			}]
 			rewards: [
-				{
-					id: "2A185528D7163E78"
-					type: "item"
-					item: "allthemodium:raw_allthemodium"
-					random_bonus: 2
-				}
 				{
 					id: "71119D300E20FCA2"
 					type: "xp"
@@ -615,9 +550,10 @@
 		}
 		{
 			x: 3.5d
-			y: 4.0d
+			y: 5.0d
 			shape: "square"
-			dependencies: ["5BDBE666E604FCAC"]
+			dependencies: ["71A43C89EB13E9A0"]
+			hide: true
 			id: "17616C60784102A6"
 			tasks: [{
 				id: "153905B8A889931F"
@@ -625,12 +561,6 @@
 				item: "allthemodium:allthemodium_axe"
 			}]
 			rewards: [
-				{
-					id: "46FAE4663AFB5703"
-					type: "item"
-					item: "allthemodium:raw_allthemodium"
-					random_bonus: 2
-				}
 				{
 					id: "3CFEB029AFDA2A46"
 					type: "xp"
@@ -646,9 +576,10 @@
 		}
 		{
 			x: 3.5d
-			y: 5.0d
+			y: 6.0d
 			shape: "square"
-			dependencies: ["5BDBE666E604FCAC"]
+			dependencies: ["71A43C89EB13E9A0"]
+			hide: true
 			id: "614B212304A85F9C"
 			tasks: [{
 				id: "1227F25DBF12B6E5"
@@ -656,12 +587,6 @@
 				item: "allthemodium:allthemodium_shovel"
 			}]
 			rewards: [
-				{
-					id: "6643F6E18F5727F4"
-					type: "item"
-					item: "allthemodium:raw_allthemodium"
-					random_bonus: 2
-				}
 				{
 					id: "00F39A0913F8D233"
 					type: "xp"
@@ -677,7 +602,7 @@
 		}
 		{
 			x: 0.0d
-			y: 9.0d
+			y: 6.5d
 			shape: "diamond"
 			description: [
 				"The Teleport Pad is used to teleport to 2 dimensions added by the ATM pack."
@@ -686,7 +611,9 @@
 				""
 				"To go to the Other, do the same thing but in the Nether."
 			]
-			dependencies: ["5BDBE666E604FCAC"]
+			hide_dependency_lines: true
+			dependencies: ["71A43C89EB13E9A0"]
+			hide: true
 			size: 2.0d
 			id: "3C322474D2F2BA99"
 			tasks: [{
@@ -696,21 +623,22 @@
 			}]
 			rewards: [
 				{
-					id: "2C9F8F16CBD7E6A1"
-					type: "item"
-					item: "allthemodium:allthemodium_ingot"
-				}
-				{
 					id: "0B4E3EEE5A9DB68C"
 					type: "xp"
 					xp: 100
+				}
+				{
+					id: "57F29BA9DE0EB0FB"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4196188979167302596L
 				}
 			]
 		}
 		{
 			title: "The Other"
-			x: 1.5d
-			y: 9.0d
+			x: 1.0d
+			y: 5.5d
 			description: [
 				"You'll find a ton of ore in the Other. It's filled to the brim with amazing ore generation, as well as Ancient Forests."
 				""
@@ -720,7 +648,7 @@
 			]
 			hide_dependency_lines: false
 			dependencies: ["3C322474D2F2BA99"]
-			size: 1.5d
+			hide: true
 			id: "58E3D29E2E034BA2"
 			tasks: [{
 				id: "7B3D9051C7A0EC60"
@@ -744,8 +672,8 @@
 		{
 			title: "The Mining Dimension"
 			icon: "allthemodium:raw_allthemodium"
-			x: -1.5d
-			y: 9.0d
+			x: -1.0d
+			y: 5.5d
 			description: [
 				"The &9Mining Dimension&r has been reworked for 1.19!"
 				""
@@ -753,7 +681,7 @@
 			]
 			hide_dependency_lines: false
 			dependencies: ["3C322474D2F2BA99"]
-			size: 1.5d
+			hide: true
 			id: "7E8FE99A3C448413"
 			tasks: [{
 				id: "110AA18477C59A28"
@@ -768,60 +696,92 @@
 		}
 		{
 			x: -1.5d
-			y: 5.5d
-			shape: "pentagon"
+			y: 4.0d
+			shape: "diamond"
+			hide_dependency_lines: false
 			dependencies: ["71A43C89EB13E9A0"]
+			hide: true
 			id: "1FBE2D8C1C3B21EE"
 			tasks: [{
 				id: "21DC9A0D99003F77"
 				type: "item"
 				item: "mysticalagriculture:allthemodium_seeds"
 			}]
-			rewards: [{
-				id: "63A5B1A4D4CF2B8A"
-				type: "xp"
-				xp: 100
-			}]
+			rewards: [
+				{
+					id: "63A5B1A4D4CF2B8A"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "146D2B7781B40CCD"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5564196992594175882L
+				}
+			]
 		}
 		{
 			x: 0.0d
-			y: 5.5d
-			shape: "pentagon"
+			y: 4.5d
+			shape: "diamond"
+			hide_dependency_lines: false
 			dependencies: ["61FDABF2C7CC1F9D"]
+			hide: true
 			id: "0C0DB81D3781FB33"
 			tasks: [{
 				id: "6CA88AF9DFAEA6B5"
 				type: "item"
 				item: "mysticalagriculture:vibranium_seeds"
 			}]
-			rewards: [{
-				id: "15BB719B9FCE235B"
-				type: "xp"
-				xp: 100
-			}]
+			rewards: [
+				{
+					id: "15BB719B9FCE235B"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "3F6FD81FD000334D"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5564196992594175882L
+				}
+			]
 		}
 		{
 			x: 1.5d
-			y: 5.5d
-			shape: "pentagon"
+			y: 4.0d
+			shape: "diamond"
+			hide_dependency_lines: false
 			dependencies: ["44760B819EB3CA68"]
+			hide: true
 			id: "3F09317D12C78271"
 			tasks: [{
 				id: "1ACAA7497BB635C0"
 				type: "item"
 				item: "mysticalagriculture:unobtainium_seeds"
 			}]
-			rewards: [{
-				id: "473ADE08455C92A6"
-				type: "xp"
-				xp: 100
-			}]
+			rewards: [
+				{
+					id: "473ADE08455C92A6"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "0822C55E3ED4098A"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5564196992594175882L
+				}
+			]
 		}
 		{
-			x: -1.5d
-			y: 6.5d
-			shape: "hexagon"
+			x: -1.0d
+			y: 3.5d
+			shape: "diamond"
+			hide_dependency_lines: false
 			dependencies: ["71A43C89EB13E9A0"]
+			hide: true
 			id: "5D8A3491889F2C4E"
 			tasks: [{
 				id: "757DE5E7C84CDD47"
@@ -836,17 +796,27 @@
 					}
 				}
 			}]
-			rewards: [{
-				id: "15475C2EF8192338"
-				type: "xp"
-				xp: 100
-			}]
+			rewards: [
+				{
+					id: "15475C2EF8192338"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "736E172147AD8566"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5564196992594175882L
+				}
+			]
 		}
 		{
-			x: 0.0d
-			y: 6.5d
-			shape: "hexagon"
+			x: 0.5d
+			y: 4.0d
+			shape: "diamond"
+			hide_dependency_lines: false
 			dependencies: ["61FDABF2C7CC1F9D"]
+			hide: true
 			id: "517A9CAA342E8FA6"
 			tasks: [{
 				id: "1DF8E3A079E13541"
@@ -861,17 +831,27 @@
 					}
 				}
 			}]
-			rewards: [{
-				id: "15EE8C5DD99F0F0B"
-				type: "xp"
-				xp: 100
-			}]
+			rewards: [
+				{
+					id: "15EE8C5DD99F0F0B"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "08C9D0B4D3679B9F"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5564196992594175882L
+				}
+			]
 		}
 		{
-			x: 1.5d
-			y: 6.5d
-			shape: "hexagon"
+			x: 2.0d
+			y: 3.5d
+			shape: "diamond"
+			hide_dependency_lines: false
 			dependencies: ["44760B819EB3CA68"]
+			hide: true
 			id: "3D6FFE360BBED088"
 			tasks: [{
 				id: "60DD22BBD1056077"
@@ -886,10 +866,206 @@
 					}
 				}
 			}]
+			rewards: [
+				{
+					id: "6DE21C164B4D377E"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "0F7489F110A30FF2"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5564196992594175882L
+				}
+			]
+		}
+		{
+			x: 0.0d
+			y: 8.5d
+			shape: "hexagon"
+			dependencies: [
+				"44760B819EB3CA68"
+				"71A43C89EB13E9A0"
+			]
+			hide: true
+			id: "2DB81CE6F647D08A"
+			tasks: [{
+				id: "7402ED40B70EE397"
+				type: "item"
+				item: "allthemodium:unobtainium_allthemodium_alloy_ingot"
+			}]
 			rewards: [{
-				id: "6DE21C164B4D377E"
-				type: "xp"
-				xp: 100
+				id: "4E13E4065EE46FBC"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 5564196992594175882L
+			}]
+		}
+		{
+			x: 1.5d
+			y: 8.0d
+			shape: "hexagon"
+			dependencies: [
+				"44760B819EB3CA68"
+				"61FDABF2C7CC1F9D"
+			]
+			hide: true
+			id: "3E0A6D2FAEEF22A8"
+			tasks: [{
+				id: "48EDC0316BE2986A"
+				type: "item"
+				item: "allthemodium:unobtainium_vibranium_alloy_ingot"
+			}]
+			rewards: [{
+				id: "0B5B60F08F952B31"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 5564196992594175882L
+			}]
+		}
+		{
+			x: -1.5d
+			y: 8.0d
+			shape: "hexagon"
+			dependencies: [
+				"71A43C89EB13E9A0"
+				"61FDABF2C7CC1F9D"
+			]
+			hide: true
+			id: "38135FFD9ED64395"
+			tasks: [{
+				id: "09214F39B42692F3"
+				type: "item"
+				item: "allthemodium:vibranium_allthemodium_alloy_ingot"
+			}]
+			rewards: [{
+				id: "3EFE94A1B3D54CCA"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 5564196992594175882L
+			}]
+		}
+		{
+			x: -0.7000000000000001d
+			y: 11.5d
+			shape: "pentagon"
+			hide_dependency_lines: false
+			dependencies: [
+				"2DB81CE6F647D08A"
+				"38135FFD9ED64395"
+				"3E0A6D2FAEEF22A8"
+			]
+			hide: true
+			id: "7D3648FF86B0EB85"
+			tasks: [{
+				id: "1BD4860E0CC120FC"
+				type: "item"
+				item: "allthemodium:alloy_sword"
+			}]
+			rewards: [{
+				id: "57239B6424179212"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 7025454341029952768L
+			}]
+		}
+		{
+			x: 0.7000000000000001d
+			y: 11.5d
+			shape: "pentagon"
+			hide_dependency_lines: false
+			dependencies: [
+				"2DB81CE6F647D08A"
+				"38135FFD9ED64395"
+				"3E0A6D2FAEEF22A8"
+			]
+			hide: true
+			id: "4881ABF8877BA572"
+			tasks: [{
+				id: "7585EE207A816B28"
+				type: "item"
+				item: "allthemodium:alloy_axe"
+			}]
+			rewards: [{
+				id: "699606E4614B1E28"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 7025454341029952768L
+			}]
+		}
+		{
+			x: -2.0d
+			y: 11.5d
+			shape: "pentagon"
+			hide_dependency_lines: false
+			dependencies: [
+				"2DB81CE6F647D08A"
+				"38135FFD9ED64395"
+				"3E0A6D2FAEEF22A8"
+			]
+			hide: true
+			id: "4F84C91128C9DCED"
+			tasks: [{
+				id: "0068F0000541A6E9"
+				type: "item"
+				item: "allthemodium:alloy_pick"
+			}]
+			rewards: [{
+				id: "3D768F8F20884784"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 7025454341029952768L
+			}]
+		}
+		{
+			x: 2.0d
+			y: 11.5d
+			shape: "pentagon"
+			hide_dependency_lines: false
+			dependencies: [
+				"2DB81CE6F647D08A"
+				"38135FFD9ED64395"
+				"3E0A6D2FAEEF22A8"
+			]
+			hide: true
+			id: "2BD4E8494F2F43E9"
+			tasks: [{
+				id: "4B44E545FE264B84"
+				type: "item"
+				item: "allthemodium:alloy_shovel"
+			}]
+			rewards: [{
+				id: "43087FBBFEB79B36"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 7025454341029952768L
+			}]
+		}
+		{
+			x: 0.0d
+			y: 10.000000000000002d
+			shape: "octagon"
+			hide_dependency_lines: false
+			dependencies: [
+				"4881ABF8877BA572"
+				"4F84C91128C9DCED"
+				"2BD4E8494F2F43E9"
+				"7D3648FF86B0EB85"
+			]
+			hide: true
+			size: 2.0d
+			id: "4AD2F0AC870672DB"
+			tasks: [{
+				id: "0E1B0C621A467BE0"
+				type: "item"
+				item: "allthemodium:alloy_paxel"
+			}]
+			rewards: [{
+				id: "7E68266B0C71E310"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 7175652334583451871L
 			}]
 		}
 	]

--- a/config/ftbquests/quests/chapters/applied_energistics_2.snbt
+++ b/config/ftbquests/quests/chapters/applied_energistics_2.snbt
@@ -1736,9 +1736,9 @@
 			x: 12.0d
 			y: -3.5d
 			description: [
-				"Naturally, AE2 provides its own way to dramatically speed up crystal growth, assuming you don't happen to have Mekanism's Enrichment Chamber on hand."
+				"Naturally, AE2 provides its own way to dramatically speed up crystal growth."
 				""
-				"Placing a water source block within a full set of 5 &bCrystal Growth Accelerators&f will reduce the growing time of crystal seeds from 20 minutes unaccelerated to as little as 24 seconds."
+				"Place these around your Budding Crystals, give them some power, and watch your crystals grow!"
 			]
 			dependencies: ["51DE3157DE3E57B8"]
 			id: "5AA3E5DFECB4AC4D"

--- a/config/ftbquests/quests/chapters/basic_power.snbt
+++ b/config/ftbquests/quests/chapters/basic_power.snbt
@@ -730,7 +730,7 @@
 			description: [
 				"If you're looking to generate a ton of power, you can start by scaling up some of the options from the &9Mid Game Power&r section. Make your &eBigger Reactors&r bigger. Upgrade your &9Thermo Gens&r to Nitro, etc. "
 				""
-				"&9Mekanism&r also has an end game power option that is tough be beat."
+				"&9Mekanism&r also has an end game power option that is tough to beat."
 				""
 				"The &5Fusion Reactor&r, when coupled with a Turbine, can easily produce 30+ million RF/tick. There will be a questline for building this in the future!"
 			]

--- a/config/ftbquests/quests/chapters/basic_power_generation.snbt
+++ b/config/ftbquests/quests/chapters/basic_power_generation.snbt
@@ -3,7 +3,7 @@
 	group: "1CF541D7529DA9CF"
 	order_index: 1
 	filename: "basic_power_generation"
-	title: "Getting Started: Part 2"
+	title: "&aChapter 2&r: &dTo The End"
 	icon: "mekanismgenerators:wind_generator"
 	default_quest_shape: ""
 	default_hide_dependency_lines: false
@@ -1093,10 +1093,10 @@
 					count: 8
 				}
 				{
-					id: "1088009042F9ECAF"
+					id: "223EBC5FE91C2210"
 					type: "random"
 					exclude_from_claim_all: true
-					table_id: 7025454341029952768L
+					table_id: 5564196992594175882L
 				}
 			]
 		}
@@ -1481,10 +1481,10 @@
 					xp: 1000
 				}
 				{
-					id: "4CE331B163AC93BE"
+					id: "11A0ACF9474F0B1C"
 					type: "loot"
 					exclude_from_claim_all: true
-					table_id: 7025454341029952768L
+					table_id: 5564196992594175882L
 				}
 			]
 		}

--- a/config/ftbquests/quests/chapters/blue_skies.snbt
+++ b/config/ftbquests/quests/chapters/blue_skies.snbt
@@ -633,7 +633,7 @@
 			y: 3.0d
 			shape: "diamond"
 			description: [
-				"Falsite Ore can be found inside the non-mountainous biomes of Everbirght."
+				"Falsite Ore can be found inside the non-mountainous biomes of Everbright."
 				""
 				"This ingot is used to strengthen the durability of almost any tool using the tool box."
 			]

--- a/config/ftbquests/quests/chapters/bounty_board.snbt
+++ b/config/ftbquests/quests/chapters/bounty_board.snbt
@@ -1,7 +1,7 @@
 {
 	id: "18A429E7F56AF5A9"
 	group: ""
-	order_index: 3
+	order_index: 4
 	filename: "bounty_board"
 	title: "Bounty Board"
 	icon: "minecraft:zombie_head"

--- a/config/ftbquests/quests/chapters/creative.snbt
+++ b/config/ftbquests/quests/chapters/creative.snbt
@@ -1,0 +1,817 @@
+{
+	id: "16956970FF49BB4D"
+	group: ""
+	order_index: 2
+	filename: "creative"
+	title: "&dCreative "
+	icon: "functionalstorage:creative_vending_upgrade"
+	default_quest_shape: "hexagon"
+	default_hide_dependency_lines: false
+	images: [
+		{
+			x: 0.0d
+			y: -4.0d
+			width: 16.0d
+			height: 4.0d
+			rotation: 0.0d
+			image: "atm:textures/questpics/creative.png"
+			hover: [ ]
+			click: ""
+			dev: false
+			corner: false
+		}
+		{
+			x: 4.0d
+			y: -3.5d
+			width: 2.0d
+			height: 2.0d
+			rotation: 20.0d
+			image: "allthetweaks:textures/item/atm_star.png"
+			hover: [ ]
+			click: ""
+			dev: false
+			corner: false
+		}
+		{
+			x: -4.0d
+			y: -3.5d
+			width: 2.0d
+			height: 2.0d
+			rotation: -20.0d
+			image: "allthetweaks:textures/item/atm_star.png"
+			hover: [ ]
+			click: ""
+			dev: false
+			corner: false
+		}
+	]
+	quests: [
+		{
+			title: "Getting Create-ive."
+			x: -4.0d
+			y: 7.0d
+			shape: "hexagon"
+			hide_dependency_lines: true
+			dependencies: ["464D0C17601E8A2B"]
+			hide: true
+			size: 1.5d
+			id: "2CF11A70229000AB"
+			tasks: [
+				{
+					id: "0CF133CEADDC504C"
+					type: "item"
+					item: "create:creative_motor"
+				}
+				{
+					id: "72936F6095FF124A"
+					type: "item"
+					item: "create:creative_blaze_cake"
+				}
+			]
+			rewards: [{
+				id: "297894608F40D90C"
+				type: "xp_levels"
+				xp_levels: 100
+			}]
+		}
+		{
+			title: "Master of Creation"
+			x: 2.0d
+			y: 0.0d
+			shape: "diamond"
+			size: 2.0d
+			id: "314537C71B1B5741"
+			tasks: [{
+				id: "4F7E4F430154E96E"
+				type: "item"
+				item: "mysticalagradditions:creative_essence"
+			}]
+			rewards: [
+				{
+					id: "398125AAF450E6E0"
+					type: "item"
+					item: "reliquary:pedestals/passive/white_passive_pedestal"
+				}
+				{
+					id: "5D91D6BA0A43CDB8"
+					type: "item"
+					item: {
+						id: "allthemodium:allthemodium_sword"
+						Count: 1b
+						tag: {
+							display: {
+								Name: "[{\"text\":\"Master of Creation\",\"italic\":false,\"color\":\"gold\"}]"
+							}
+							Enchantments: [{ }]
+						}
+					}
+				}
+				{
+					id: "0E67E7028A90F200"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7025454341029952768L
+				}
+			]
+		}
+		{
+			title: "Master of The Sky"
+			x: 2.0d
+			y: 6.0d
+			shape: "diamond"
+			size: 2.0d
+			id: "088E6EA318D25659"
+			tasks: [{
+				id: "48CC30220D7FC2C9"
+				type: "item"
+				item: "allthetweaks:nexium_emitter"
+			}]
+			rewards: [
+				{
+					id: "4D0E3B723F4F7569"
+					type: "item"
+					item: "reliquary:pedestals/passive/white_passive_pedestal"
+				}
+				{
+					id: "5EE93B9969BDE61D"
+					type: "item"
+					item: {
+						id: "allthemodium:allthemodium_sword"
+						Count: 1b
+						tag: {
+							display: {
+								Name: "[{\"text\":\"Master of The Sky\",\"italic\":false,\"color\":\"gold\"}]"
+							}
+							Enchantments: [{ }]
+						}
+					}
+				}
+				{
+					id: "4C75ED9B4A7749CC"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7025454341029952768L
+				}
+			]
+		}
+		{
+			title: "Master of The Elements"
+			x: -2.0d
+			y: 0.0d
+			shape: "diamond"
+			size: 2.0d
+			id: "29FFA090ADB56195"
+			tasks: [{
+				id: "3F1E9259BB90D044"
+				type: "item"
+				item: "allthetweaks:philosophers_fuel"
+			}]
+			rewards: [
+				{
+					id: "2609BCC306245807"
+					type: "item"
+					item: "reliquary:pedestals/passive/white_passive_pedestal"
+				}
+				{
+					id: "52F653A7E72EFC5B"
+					type: "item"
+					item: {
+						id: "allthemodium:allthemodium_sword"
+						Count: 1b
+						tag: {
+							display: {
+								Name: "[{\"text\":\"Master of The Elements\",\"italic\":false,\"color\":\"gold\"}]"
+							}
+							Enchantments: [{ }]
+						}
+					}
+				}
+				{
+					id: "00AD263752FFCF7C"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7175652334583451871L
+				}
+			]
+		}
+		{
+			title: "Master of Space"
+			x: -3.0d
+			y: 5.0d
+			shape: "diamond"
+			size: 2.0d
+			id: "296E89E2DF857B25"
+			tasks: [{
+				id: "56F3DEFF2D46B881"
+				type: "item"
+				item: "allthetweaks:pulsating_black_hole"
+			}]
+			rewards: [
+				{
+					id: "405BF0FCC81D5658"
+					type: "item"
+					item: "reliquary:pedestals/passive/white_passive_pedestal"
+				}
+				{
+					id: "356705C6E0F0F388"
+					type: "item"
+					item: {
+						id: "allthemodium:allthemodium_sword"
+						Count: 1b
+						tag: {
+							display: {
+								Name: "[{\"text\":\"Master of Space\",\"italic\":false,\"color\":\"gold\"}]"
+							}
+							Enchantments: [{ }]
+						}
+					}
+				}
+				{
+					id: "599218366225810D"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7175652334583451871L
+				}
+			]
+		}
+		{
+			title: "Master of The Universe"
+			x: 0.0d
+			y: -1.0d
+			shape: "hexagon"
+			size: 2.0d
+			id: "794EC696A3B7DAC3"
+			tasks: [{
+				id: "10834451DAC877C5"
+				type: "item"
+				item: "allthetweaks:dimensional_seed"
+			}]
+			rewards: [
+				{
+					id: "44165A6E4A341DF6"
+					type: "item"
+					item: "reliquary:pedestals/passive/white_passive_pedestal"
+				}
+				{
+					id: "27D843D0710D4CD6"
+					type: "item"
+					item: {
+						id: "allthemodium:allthemodium_sword"
+						Count: 1b
+						tag: {
+							display: {
+								Name: "[{\"text\":\"Master of The Universe\",\"italic\":false,\"color\":\"gold\"}]"
+							}
+							Enchantments: [{ }]
+						}
+					}
+				}
+				{
+					id: "1C0357D6C72283DA"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7025454341029952768L
+				}
+			]
+		}
+		{
+			title: "&6ATM Star"
+			x: 0.0d
+			y: 3.0d
+			shape: "octagon"
+			subtitle: "Take over the world."
+			description: [
+				"The ATM Star."
+				""
+				"This is needed to craft Creative items."
+			]
+			dependencies: [
+				"29FFA090ADB56195"
+				"4A629299C15E7E81"
+				"314537C71B1B5741"
+				"24CE3AF373180CC9"
+				"794EC696A3B7DAC3"
+				"296E89E2DF857B25"
+				"20408CB5A15237EA"
+				"5477FBAEBDE2D10B"
+				"3615BAFD4F2AD479"
+				"088E6EA318D25659"
+				"3047DB8DF8454D18"
+				"7F3C377120EF35B8"
+			]
+			size: 3.0d
+			id: "464D0C17601E8A2B"
+			tasks: [{
+				id: "5F6988D125AAB233"
+				type: "item"
+				item: "allthetweaks:atm_star"
+			}]
+			rewards: [
+				{
+					id: "1A44EDC903F8E8D7"
+					type: "item"
+					item: "reliquary:pedestals/passive/white_passive_pedestal"
+				}
+				{
+					id: "382984099BD8DCEF"
+					type: "item"
+					item: "allthetweaks:trophy_atm"
+				}
+			]
+		}
+		{
+			title: "Master of....Patrick?"
+			x: 0.0d
+			y: 7.0d
+			size: 2.0d
+			id: "24CE3AF373180CC9"
+			tasks: [{
+				id: "7222BF35C9281295"
+				type: "item"
+				item: "allthetweaks:patrick_star"
+			}]
+			rewards: [
+				{
+					id: "67087A134C6947DF"
+					type: "item"
+					item: "reliquary:pedestals/passive/white_passive_pedestal"
+				}
+				{
+					id: "7A79D37078705E41"
+					type: "item"
+					item: {
+						id: "minecraft:trident"
+						Count: 1b
+						tag: {
+							Damage: 0
+							Enchantments: [
+								{
+									lvl: 5
+									id: "sharpness"
+								}
+								{
+									lvl: 3
+									id: "looting"
+								}
+								{
+									lvl: 3
+									id: "sweeping"
+								}
+							]
+							display: {
+								Name: "\"Master of...Patrick?\""
+							}
+						}
+					}
+				}
+				{
+					id: "5D026B4AC588B08C"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4196188979167302596L
+				}
+			]
+		}
+		{
+			title: "Master of Oblivion"
+			x: 3.0d
+			y: 1.0d
+			shape: "diamond"
+			size: 2.0d
+			id: "20408CB5A15237EA"
+			tasks: [{
+				id: "64A1AE71DDC8F0B0"
+				type: "item"
+				item: "allthetweaks:oblivion_shard"
+			}]
+			rewards: [
+				{
+					id: "7812BBD0CC80C2A8"
+					type: "item"
+					item: "reliquary:pedestals/passive/white_passive_pedestal"
+				}
+				{
+					id: "2C5AB04570DBEC0C"
+					type: "item"
+					item: {
+						id: "allthemodium:allthemodium_sword"
+						Count: 1b
+						tag: {
+							display: {
+								Name: "[{\"text\":\"Master of Oblivion\",\"italic\":false,\"color\":\"gold\"}]"
+							}
+							Enchantments: [{ }]
+						}
+					}
+				}
+				{
+					id: "5782E3663FC50E5F"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4196188979167302596L
+				}
+			]
+		}
+		{
+			title: "Master of Reality"
+			x: 3.0d
+			y: 5.0d
+			shape: "diamond"
+			hide: false
+			size: 2.0d
+			id: "4A629299C15E7E81"
+			tasks: [{
+				id: "52DDA8A874F605CB"
+				type: "item"
+				item: "allthetweaks:improbable_probability_device"
+			}]
+			rewards: [
+				{
+					id: "2EFB7B4F97D220BF"
+					type: "item"
+					item: "reliquary:pedestals/passive/white_passive_pedestal"
+				}
+				{
+					id: "28AA46A8D4DD01E6"
+					type: "item"
+					item: {
+						id: "allthemodium:allthemodium_sword"
+						Count: 1b
+						tag: {
+							display: {
+								Name: "[{\"text\":\"Master of Reality\",\"italic\":false,\"color\":\"gold\"}]"
+							}
+							Enchantments: [{ }]
+						}
+					}
+				}
+				{
+					id: "517C037090107437"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5564196992594175882L
+				}
+			]
+		}
+		{
+			title: "Master of Dragons"
+			x: -3.0d
+			y: 1.0d
+			shape: "diamond"
+			size: 2.0d
+			id: "3615BAFD4F2AD479"
+			tasks: [{
+				id: "48CE28F5C1683093"
+				type: "item"
+				item: "allthetweaks:dragon_soul"
+			}]
+			rewards: [
+				{
+					id: "7952CD1C4621CA26"
+					type: "item"
+					item: "reliquary:pedestals/passive/white_passive_pedestal"
+				}
+				{
+					id: "26B9DA9F21EE83C4"
+					type: "item"
+					item: {
+						id: "allthemodium:allthemodium_sword"
+						Count: 1b
+						tag: {
+							display: {
+								Name: "[{\"text\":\"Master of Dragons\",\"italic\":false,\"color\":\"gold\"}]"
+							}
+							Enchantments: [{ }]
+						}
+					}
+				}
+				{
+					id: "17722771164A4D2C"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5564196992594175882L
+				}
+			]
+		}
+		{
+			title: "Master of The Undead"
+			x: -2.0d
+			y: 6.0d
+			shape: "diamond"
+			size: 2.0d
+			id: "5477FBAEBDE2D10B"
+			tasks: [{
+				id: "042808E2D5E02DED"
+				type: "item"
+				item: "allthetweaks:withers_compass"
+			}]
+			rewards: [
+				{
+					id: "5241889A5D8B8931"
+					type: "item"
+					item: "reliquary:pedestals/passive/white_passive_pedestal"
+				}
+				{
+					id: "180F365B4EDFF409"
+					type: "item"
+					item: {
+						id: "allthemodium:allthemodium_sword"
+						Count: 1b
+						tag: {
+							display: {
+								Name: "[{\"text\":\"Master of The Undead\",\"italic\":false,\"color\":\"gold\"}]"
+							}
+							Enchantments: [{ }]
+						}
+					}
+				}
+				{
+					id: "62D680E24CAAD6F4"
+					type: "random"
+					title: "Random Mythic Reward"
+					table_id: 5196609362437981520L
+				}
+			]
+		}
+		{
+			title: "Infinite Mana"
+			x: -4.0d
+			y: -1.0d
+			shape: "hexagon"
+			hide_dependency_lines: true
+			dependencies: ["464D0C17601E8A2B"]
+			hide: true
+			size: 1.5d
+			id: "5C7B81756CA58056"
+			tasks: [
+				{
+					id: "775BD503F830BB6C"
+					type: "item"
+					item: "botania:creative_pool"
+				}
+				{
+					id: "7FDBB3698C087D8B"
+					type: "item"
+					item: {
+						id: "botania:mana_tablet"
+						Count: 1b
+						tag: {
+							mana: 500000
+							creative: 1b
+						}
+					}
+				}
+			]
+			rewards: [
+				{
+					id: "753A05B6079F4FBA"
+					type: "item"
+					item: "botania:gaia_head"
+				}
+				{
+					id: "7D74C1F49E9E5D28"
+					type: "xp_levels"
+					xp_levels: 100
+				}
+			]
+		}
+		{
+			title: "Set For Life"
+			x: 0.0d
+			y: 12.0d
+			shape: "hexagon"
+			subtitle: "Enough to make everything in the pack?"
+			description: ["If you make 9 Stars, or enough to make an ATM Star Block, you'll be able to create a &dStarry Bee&r. This bee gives you &6ATM Star Shards&r from their combs."]
+			hide_dependency_lines: true
+			dependencies: [
+				"2CF11A70229000AB"
+				"5C7B81756CA58056"
+				"464D0C17601E8A2B"
+			]
+			hide: true
+			size: 3.0d
+			id: "6E6FDF551EA4FF1A"
+			tasks: [
+				{
+					id: "529AEED3E1A07228"
+					type: "item"
+					item: "allthetweaks:atm_star_block"
+				}
+				{
+					id: "5C995984E37F6C5A"
+					type: "item"
+					item: {
+						id: "productivebees:configurable_honeycomb"
+						Count: 1b
+						tag: {
+							EntityTag: {
+								type: "productivebees:starry"
+							}
+						}
+					}
+				}
+			]
+		}
+		{
+			title: "Building The Frame"
+			x: 4.0d
+			y: 3.0d
+			shape: "hexagon"
+			size: 2.0d
+			id: "7F3C377120EF35B8"
+			tasks: [
+				{
+					id: "44051D66A5EF2F12"
+					type: "item"
+					item: "allthemodium:unobtainium_allthemodium_alloy_block"
+					count: 28L
+				}
+				{
+					id: "6BBB6B41C0B4F68B"
+					type: "item"
+					item: {
+						id: "allthemodium:unobtainium_vibranium_alloy_block"
+						Count: 1b
+						tag: {
+							HideFlags: 1
+							Enchantments: [{
+								lvl: 1s
+								id: "minecraft:unbreaking"
+							}]
+							display: {
+								Name: "[{\"text\":\"Awakened Unobtainium-Vibranium Alloy Block\",\"italic\":false}]"
+							}
+						}
+					}
+					count: 2L
+				}
+			]
+			rewards: [
+				{
+					id: "654E148667B50941"
+					type: "item"
+					item: "reliquary:pedestals/passive/white_passive_pedestal"
+				}
+				{
+					id: "6415E5859663BDA3"
+					type: "item"
+					item: {
+						id: "allthemodium:alloy_sword"
+						Count: 1b
+						tag: {
+							display: {
+								Name: "[{\"text\":\"Master of The Alloy\",\"italic\":false}]"
+							}
+							Enchantments: [{ }]
+						}
+					}
+				}
+				{
+					id: "7BC90DAF90BA1F33"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7025454341029952768L
+				}
+			]
+		}
+		{
+			title: "Harnessing the Power of the Nether"
+			x: -4.0d
+			y: 3.0d
+			shape: "hexagon"
+			size: 2.0d
+			id: "3047DB8DF8454D18"
+			tasks: [{
+				id: "15781E3FD52A7921"
+				type: "item"
+				item: "allthecompressed:nether_star_block_3x"
+				count: 15L
+			}]
+			rewards: [
+				{
+					id: "65E1A5BDD454B39F"
+					type: "item"
+					item: {
+						id: "minecraft:nether_star"
+						Count: 1b
+						tag: {
+							display: {
+								Name: "[{\"text\":\"Star of The Gods\",\"italic\":false,\"color\":\"dark_purple\"}]"
+							}
+							Enchantments: [{ }]
+						}
+					}
+				}
+				{
+					id: "0C5B50A2C82FD978"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5564196992594175882L
+				}
+			]
+		}
+		{
+			x: 0.0d
+			y: 9.5d
+			shape: "diamond"
+			hide_dependency_lines: true
+			dependencies: ["464D0C17601E8A2B"]
+			hide: true
+			size: 2.0d
+			id: "3DA9649DC32DDF7C"
+			tasks: [{
+				id: "425542D0B83DFC9E"
+				type: "item"
+				item: "allthetweaks:atm_star_shard"
+			}]
+			rewards: [{
+				id: "1483F0383FB2B474"
+				type: "xp"
+				xp: 1000
+			}]
+		}
+		{
+			x: 1.5d
+			y: 9.5d
+			shape: "diamond"
+			dependencies: ["3DA9649DC32DDF7C"]
+			id: "182FD093AEDC84D4"
+			tasks: [{
+				id: "13CDE75623F0EBD5"
+				type: "item"
+				item: "thermal:machine_efficiency_creative_augment"
+			}]
+			rewards: [{
+				id: "2F45E675F1DAD3BB"
+				type: "xp"
+				xp: 1000
+			}]
+		}
+		{
+			x: -1.5d
+			y: 9.5d
+			shape: "diamond"
+			dependencies: ["3DA9649DC32DDF7C"]
+			id: "4F420AB27F056D9C"
+			tasks: [{
+				id: "23419C4DB7C1E5CB"
+				type: "item"
+				item: "pipez:infinity_upgrade"
+			}]
+			rewards: [
+				{
+					id: "19B74A3FD58E767F"
+					type: "item"
+					item: "pipez:universal_pipe"
+					count: 64
+				}
+				{
+					id: "7AABD1369C9574CC"
+					type: "xp"
+					xp: 1000
+				}
+			]
+		}
+		{
+			x: 4.0d
+			y: -1.0d
+			shape: "hexagon"
+			hide_dependency_lines: true
+			dependencies: ["464D0C17601E8A2B"]
+			hide: true
+			size: 1.5d
+			id: "695C8159D28F16B7"
+			tasks: [{
+				id: "2E44EAD876619015"
+				type: "item"
+				item: "ars_nouveau:creative_source_jar"
+			}]
+			rewards: [{
+				id: "3841CBE0A9BBA8A6"
+				type: "xp"
+				xp: 1000
+			}]
+		}
+		{
+			x: 4.0d
+			y: 7.0d
+			shape: "hexagon"
+			hide_dependency_lines: true
+			dependencies: ["464D0C17601E8A2B"]
+			hide: true
+			size: 1.5d
+			id: "3F833B656A0DBB0E"
+			tasks: [{
+				id: "5973E65E0C940E27"
+				type: "item"
+				item: "ars_nouveau:creative_spell_book"
+			}]
+			rewards: [{
+				id: "0886FF12E77AAC17"
+				type: "xp"
+				xp: 1000
+			}]
+		}
+	]
+	quest_links: [ ]
+}

--- a/config/ftbquests/quests/chapters/elementalcraft.snbt
+++ b/config/ftbquests/quests/chapters/elementalcraft.snbt
@@ -1432,6 +1432,7 @@
 							}
 						}
 					}
+					match_nbt: true
 				}
 				{
 					id: "2B52FE4D4A70E2DA"
@@ -1445,6 +1446,7 @@
 							}
 						}
 					}
+					match_nbt: true
 				}
 				{
 					id: "3442E09D52543E37"
@@ -1458,6 +1460,7 @@
 							}
 						}
 					}
+					match_nbt: true
 				}
 			]
 			rewards: [{
@@ -1485,6 +1488,7 @@
 							}
 						}
 					}
+					match_nbt: true
 				}
 				{
 					id: "454565C9174BA435"
@@ -1498,6 +1502,7 @@
 							}
 						}
 					}
+					match_nbt: true
 				}
 				{
 					id: "74A65C7753C85DF4"
@@ -1511,6 +1516,7 @@
 							}
 						}
 					}
+					match_nbt: true
 				}
 			]
 			rewards: [{
@@ -1538,6 +1544,7 @@
 							}
 						}
 					}
+					match_nbt: true
 				}
 				{
 					id: "107464BB6EDB6FE5"
@@ -1551,6 +1558,7 @@
 							}
 						}
 					}
+					match_nbt: true
 				}
 				{
 					id: "30B4C23E8010CB4C"
@@ -1564,6 +1572,7 @@
 							}
 						}
 					}
+					match_nbt: true
 				}
 			]
 			rewards: [{
@@ -1619,4 +1628,5 @@
 			}]
 		}
 	]
+	quest_links: [ ]
 }

--- a/config/ftbquests/quests/chapters/food_and_farming.snbt
+++ b/config/ftbquests/quests/chapters/food_and_farming.snbt
@@ -1199,9 +1199,9 @@
 			shape: "diamond"
 			subtitle: "Why Use 3 Block when 1 Block Do Trick"
 			description: [
-				"This block provides water the multi-block kitchen."
+				"This block provides water to the multi-block kitchen."
 				""
-				"It can also provide infinite water, and can pump water out via cables or pipes."
+				"It can also provide infinite water by pumping water out via cables or pipes."
 			]
 			hide_dependency_lines: true
 			dependencies: ["28C9EDBF6607E180"]
@@ -1236,7 +1236,7 @@
 			y: 4.0d
 			shape: "diamond"
 			description: [
-				"&9Botany Pots&r makes its return to the All The Mods modpacks."
+				"&9Botany Pots&r makes it easy to grow your resources!"
 				""
 				"These pots auto-grow almost anything you put into them, and can even be upgraded for automation!"
 			]

--- a/config/ftbquests/quests/chapters/getting_started.snbt
+++ b/config/ftbquests/quests/chapters/getting_started.snbt
@@ -3,7 +3,7 @@
 	group: "1CF541D7529DA9CF"
 	order_index: 0
 	filename: "getting_started"
-	title: "Getting Started"
+	title: "&aChapter 1&r: &bGetting Started"
 	icon: "minecraft:furnace"
 	default_quest_shape: "circle"
 	default_hide_dependency_lines: false

--- a/config/ftbquests/quests/chapters/mekanism.snbt
+++ b/config/ftbquests/quests/chapters/mekanism.snbt
@@ -1657,9 +1657,16 @@
 					item: "mekanism:chemical_oxidizer"
 				}
 				{
-					id: "4FFA4CDB37CDFCC8"
+					id: "3B5A283601BEADA0"
 					type: "item"
-					item: "mekanism:dust_sulfur"
+					title: "Any Sulfur Dust"
+					item: {
+						id: "itemfilters:tag"
+						Count: 1b
+						tag: {
+							value: "forge:dusts/sulfur"
+						}
+					}
 				}
 			]
 			rewards: [

--- a/config/ftbquests/quests/chapters/refined_storage.snbt
+++ b/config/ftbquests/quests/chapters/refined_storage.snbt
@@ -178,7 +178,7 @@
 			}]
 		}
 		{
-			x: -0.5d
+			x: 0.5d
 			y: 4.0d
 			shape: "diamond"
 			description: ["The 1024k Storage Disk can store 1024000 items."]
@@ -196,7 +196,7 @@
 			}]
 		}
 		{
-			x: -1.0d
+			x: 1.0d
 			y: 4.5d
 			shape: "diamond"
 			description: ["The 4096k Storage Disk can store 4096000 items."]
@@ -221,7 +221,7 @@
 			]
 		}
 		{
-			x: -0.5d
+			x: 0.5d
 			y: 5.0d
 			shape: "diamond"
 			description: ["The 16384k Storage Disk can store 16384000 items."]
@@ -246,7 +246,7 @@
 			]
 		}
 		{
-			x: 0.5d
+			x: -0.5d
 			y: 5.0d
 			shape: "diamond"
 			description: ["The 262m Storage Disk can store.... well....  262m items."]
@@ -276,7 +276,7 @@
 			]
 		}
 		{
-			x: 1.0d
+			x: -1.0d
 			y: 4.5d
 			shape: "diamond"
 			description: [
@@ -323,8 +323,11 @@
 				""
 				"These are used to house the larger Disk Drives. "
 			]
-			dependencies: ["3751015CD5C84134"]
-			dependency_requirement: "one_started"
+			dependencies: [
+				"3751015CD5C84134"
+				"3F8EEE1AD4420702"
+			]
+			dependency_requirement: "one_completed"
 			size: 1.5d
 			id: "7DD638E4111D66E7"
 			tasks: [{
@@ -1070,7 +1073,6 @@
 			]
 			dependencies: ["59F5ED931FD70C55"]
 			hide: true
-			dependency_requirement: "one_started"
 			min_width: 300
 			id: "65C8A43FEDBA3835"
 			tasks: [{
@@ -1585,8 +1587,8 @@
 			}]
 		}
 		{
-			x: 0.5d
-			y: 4.0d
+			x: 0.0d
+			y: 4.5d
 			shape: "diamond"
 			description: ["Infinite item storage!"]
 			hide_dependency_lines: false

--- a/config/ftbquests/quests/chapters/resourceful_ways.snbt
+++ b/config/ftbquests/quests/chapters/resourceful_ways.snbt
@@ -419,14 +419,15 @@
 			}]
 			rewards: [
 				{
-					id: "4C0C0FA818D81804"
-					type: "random"
-					exclude_from_claim_all: true
-				}
-				{
 					id: "65700E61B22FED09"
 					type: "xp"
 					xp: 10
+				}
+				{
+					id: "04F3E39419EC5B0E"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
 				}
 			]
 		}

--- a/config/ftbquests/quests/chapters/resourceful_ways.snbt
+++ b/config/ftbquests/quests/chapters/resourceful_ways.snbt
@@ -4,14 +4,23 @@
 	order_index: 1
 	filename: "resourceful_ways"
 	title: "Mystical Agriculture"
+	icon: "mysticalagriculture:inferium_essence"
 	default_quest_shape: ""
 	default_hide_dependency_lines: false
+	default_min_width: 200
 	quests: [
 		{
-			title: "Mystical Path"
-			x: -3.0d
-			y: 1.5d
-			shape: "rsquare"
+			title: "&dThe Infusion Altar&r"
+			x: -18.799999999999997d
+			y: 0.7999999999999998d
+			shape: "diamond"
+			description: [
+				"The &9Infusion Altar&r is the bread and butter of creating &aSeeds&r in the mod. You'll need to create the Altar itself, as well as 8 Pedestals."
+				""
+				"Placing the Altar down first will show you where to put the Pedestals. To craft a seed, place the required mats in each pedestal, then give a redstone signal to the Altar."
+			]
+			dependencies: ["54D6F7F8FE859729"]
+			hide: true
 			id: "6D750A38944E9B68"
 			tasks: [
 				{
@@ -26,23 +35,23 @@
 					count: 8L
 				}
 			]
+			rewards: [
+				{
+					id: "346AC7E6CDA2F58E"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 6553016128235291313L
+				}
+				{
+					id: "682208F5DF52149E"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			title: "Growing Inferium"
-			x: 0.0d
-			y: -1.5d
-			shape: "diamond"
-			dependencies: ["1CC4F8570A7A99EB"]
-			id: "0A731CA172FB9188"
-			tasks: [{
-				id: "53A2218A89F26A4E"
-				type: "item"
-				item: "mysticalagriculture:inferium_seeds"
-			}]
-		}
-		{
-			x: -3.0d
-			y: -2.0d
+			x: -20.0d
+			y: -5.0d
 			shape: "diamond"
 			dependencies: ["7DFF18CFEB0B8DBE"]
 			id: "54D72C234EA76054"
@@ -51,23 +60,62 @@
 				type: "item"
 				item: "mysticalagriculture:air_seeds"
 			}]
+			rewards: [
+				{
+					id: "49F3A55BE12A58F1"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 6553016128235291313L
+				}
+				{
+					id: "46C102C711A54E39"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			title: "The Inferior Essence"
-			x: -2.5d
-			y: 0.0d
+			title: "Growing &aInferium&r"
+			x: -19.5d
+			y: -3.0d
 			shape: "circle"
+			description: [
+				"You'll want to start growing &aInferium&r as soon as you can!"
+				""
+				"While not required for growing Inferium seeds, you can also create &eEssence Farmland&r that will increase the growth speed of the seeds. However, certain seeds will require certain farmlands to be planted on."
+			]
 			dependencies: ["1CC4F8570A7A99EB"]
+			hide: true
 			id: "7DFF18CFEB0B8DBE"
-			tasks: [{
-				id: "3BE2200A7B852974"
-				type: "item"
-				item: "mysticalagriculture:inferium_farmland"
-			}]
+			tasks: [
+				{
+					id: "3BE2200A7B852974"
+					type: "item"
+					item: "mysticalagriculture:inferium_farmland"
+				}
+				{
+					id: "11EDB05BC54E502C"
+					type: "item"
+					item: "mysticalagriculture:inferium_seeds"
+				}
+			]
+			rewards: [
+				{
+					id: "6532E45AED2EBAC6"
+					type: "item"
+					item: "mysticalagriculture:inferium_essence"
+					random_bonus: 3
+				}
+				{
+					id: "1C0AB29F65E420FE"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -2.0d
-			y: -2.0d
+			x: -19.0d
+			y: -5.0d
 			shape: "diamond"
 			dependencies: ["7DFF18CFEB0B8DBE"]
 			id: "1E7DC8E0493BE99E"
@@ -76,10 +124,23 @@
 				type: "item"
 				item: "mysticalagriculture:water_seeds"
 			}]
+			rewards: [
+				{
+					id: "4330EABCBC353D63"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 6553016128235291313L
+				}
+				{
+					id: "30A249AAB4B966F9"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -2.5d
-			y: -2.5d
+			x: -19.5d
+			y: -5.5d
 			shape: "diamond"
 			dependencies: ["7DFF18CFEB0B8DBE"]
 			id: "712EB19B26D405DD"
@@ -88,10 +149,23 @@
 				type: "item"
 				item: "mysticalagriculture:ice_seeds"
 			}]
+			rewards: [
+				{
+					id: "7965997B4D102A69"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 6553016128235291313L
+				}
+				{
+					id: "54FC34F2AB895D6B"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -3.0d
-			y: -1.0d
+			x: -20.0d
+			y: -4.0d
 			shape: "diamond"
 			dependencies: ["7DFF18CFEB0B8DBE"]
 			id: "409A92D40F539485"
@@ -100,10 +174,23 @@
 				type: "item"
 				item: "mysticalagriculture:wood_seeds"
 			}]
+			rewards: [
+				{
+					id: "20E573CA1EB80E50"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 6553016128235291313L
+				}
+				{
+					id: "6FD5D0C6234A07C2"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -2.0d
-			y: -1.0d
+			x: -19.0d
+			y: -4.0d
 			shape: "diamond"
 			dependencies: ["7DFF18CFEB0B8DBE"]
 			id: "1609BF52108238B0"
@@ -112,10 +199,23 @@
 				type: "item"
 				item: "mysticalagriculture:stone_seeds"
 			}]
+			rewards: [
+				{
+					id: "5D70E25A9AB6D15B"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 6553016128235291313L
+				}
+				{
+					id: "3E4B9513E8527E5B"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -2.5d
-			y: -1.5d
+			x: -19.5d
+			y: -4.5d
 			shape: "diamond"
 			dependencies: ["7DFF18CFEB0B8DBE"]
 			id: "4526E151BAE88310"
@@ -124,10 +224,23 @@
 				type: "item"
 				item: "mysticalagriculture:dirt_seeds"
 			}]
+			rewards: [
+				{
+					id: "4B930B2E6AF3EFF7"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 6553016128235291313L
+				}
+				{
+					id: "6831467D3DD66DD8"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -3.0d
-			y: -3.0d
+			x: -20.0d
+			y: -6.0d
 			shape: "diamond"
 			dependencies: ["7DFF18CFEB0B8DBE"]
 			id: "13124A7E22999850"
@@ -136,10 +249,22 @@
 				type: "item"
 				item: "mysticalagriculture:earth_seeds"
 			}]
+			rewards: [
+				{
+					id: "31B2A02A5855D5BB"
+					type: "random"
+					exclude_from_claim_all: true
+				}
+				{
+					id: "14A3162D86090C91"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -2.0d
-			y: -3.0d
+			x: -19.0d
+			y: -6.0d
 			shape: "diamond"
 			dependencies: ["7DFF18CFEB0B8DBE"]
 			id: "27A0BCE75F198A82"
@@ -148,19 +273,34 @@
 				type: "item"
 				item: "mysticalagriculture:fire_seeds"
 			}]
+			rewards: [
+				{
+					id: "6F44B5C8B4A4E6AC"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 6553016128235291313L
+				}
+				{
+					id: "33D3392AF782C1E4"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			title: "Circle of Souls"
-			x: -2.0d
-			y: 1.5d
-			shape: "rsquare"
+			title: "Creating Mob Seeds"
+			x: -18.799999999999997d
+			y: 2.3d
+			shape: "diamond"
 			description: [
-				"Some seeds require you to kill the mobs needed to get the seeds."
+				"Most seeds are simple to make, but to make &9Mob Seeds&r, you'll need to head to the Nether to pick up some &8Soulium&r."
 				""
-				"It does require 4 jars of the same creature. The dagger helps a lot when killing the passive mobs."
+				"With the stone and ore that you find, you'll need to use these to make the &3Soulium Dagger&r and &3Soul Jars&r. Using the dagger to kill mobs, you'll be able to gather their &bsouls&r, which are used in the Infusion Altar to create the respective mob seeds."
 				""
-				"There is also the experience jar, it's just for the experience seed."
+				"Alternatively, you can fill Soul Jars inside of the &3Soul Extractor&r by inserting a jar and using mob items to fill them. For example, adding Rotten Flesh will give a portion of a Zombie Soul."
 			]
+			dependencies: ["54D6F7F8FE859729"]
+			hide: true
 			id: "75560045ED084900"
 			tasks: [
 				{
@@ -180,27 +320,45 @@
 					}
 				}
 				{
-					id: "57F62564C8D35376"
+					id: "7E7F031E78DE4E4D"
 					type: "item"
-					item: "mysticalagriculture:experience_capsule"
+					item: "mysticalagriculture:soul_extractor"
+				}
+			]
+			rewards: [
+				{
+					id: "1EADD864A3D552F0"
+					type: "item"
+					item: "mysticalagriculture:soul_jar"
+					random_bonus: 2
+				}
+				{
+					id: "1ACB29D670B09D06"
+					type: "xp"
+					xp: 10
 				}
 			]
 		}
 		{
-			x: -5.0d
-			y: 0.0d
+			x: -14.5d
+			y: -3.0d
 			shape: "circle"
-			dependencies: ["7DFF18CFEB0B8DBE"]
+			dependencies: ["73350AD668200E99"]
 			id: "576ABF43FCF886B7"
 			tasks: [{
 				id: "5093432E189F5F6F"
 				type: "item"
 				item: "mysticalagriculture:prudentium_farmland"
 			}]
+			rewards: [{
+				id: "3FBF79AC233906E2"
+				type: "xp"
+				xp: 10
+			}]
 		}
 		{
-			x: -4.5d
-			y: -1.0d
+			x: -14.0d
+			y: -4.0d
 			shape: "diamond"
 			dependencies: ["576ABF43FCF886B7"]
 			id: "31BAC57972148E1F"
@@ -209,10 +367,23 @@
 				type: "item"
 				item: "mysticalagriculture:coral_seeds"
 			}]
+			rewards: [
+				{
+					id: "09AB334528EE9AF6"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "4CFA4CEFB44E7800"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -5.0d
-			y: -2.5d
+			x: -14.5d
+			y: -5.5d
 			shape: "diamond"
 			dependencies: ["576ABF43FCF886B7"]
 			id: "0E25CDB09FE88A63"
@@ -221,10 +392,23 @@
 				type: "item"
 				item: "mysticalagriculture:saltpeter_seeds"
 			}]
+			rewards: [
+				{
+					id: "21849C2BFF8A871B"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "0E9C59288BA4FF77"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -5.5d
-			y: -1.0d
+			x: -15.0d
+			y: -4.0d
 			shape: "diamond"
 			dependencies: ["576ABF43FCF886B7"]
 			id: "573885D6EF32B7BC"
@@ -233,10 +417,22 @@
 				type: "item"
 				item: "mysticalagriculture:coal_seeds"
 			}]
+			rewards: [
+				{
+					id: "4C0C0FA818D81804"
+					type: "random"
+					exclude_from_claim_all: true
+				}
+				{
+					id: "65700E61B22FED09"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -5.0d
-			y: -1.5d
+			x: -14.5d
+			y: -4.5d
 			shape: "diamond"
 			dependencies: ["576ABF43FCF886B7"]
 			id: "2777FEB022346947"
@@ -245,10 +441,23 @@
 				type: "item"
 				item: "mysticalagriculture:dye_seeds"
 			}]
+			rewards: [
+				{
+					id: "653F8A5C9398ABDA"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "188AD13C9980BBFC"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -4.5d
-			y: -3.0d
+			x: -14.0d
+			y: -6.0d
 			shape: "diamond"
 			dependencies: ["576ABF43FCF886B7"]
 			id: "2A049419C78E96F4"
@@ -257,10 +466,23 @@
 				type: "item"
 				item: "mysticalagriculture:aluminum_seeds"
 			}]
+			rewards: [
+				{
+					id: "6CBADE1B42273117"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "23686842869FACF1"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -4.5d
-			y: -2.0d
+			x: -14.0d
+			y: -5.0d
 			shape: "diamond"
 			dependencies: ["576ABF43FCF886B7"]
 			id: "594F6ED00D1619EE"
@@ -269,10 +491,23 @@
 				type: "item"
 				item: "mysticalagriculture:honey_seeds"
 			}]
+			rewards: [
+				{
+					id: "0F37ACC69BCDAA63"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "21228B82977D645E"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -7.5d
-			y: -2.5d
+			x: -9.5d
+			y: -5.5d
 			shape: "diamond"
 			dependencies: ["76071C22A73A2026"]
 			id: "5A17C762CDB680B5"
@@ -281,10 +516,23 @@
 				type: "item"
 				item: "mysticalagriculture:copper_seeds"
 			}]
+			rewards: [
+				{
+					id: "723CA9990B132BAF"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "73420F3B7FD01279"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -5.5d
-			y: -2.0d
+			x: -15.0d
+			y: -5.0d
 			shape: "diamond"
 			dependencies: ["576ABF43FCF886B7"]
 			id: "40B13424FA523E11"
@@ -293,10 +541,23 @@
 				type: "item"
 				item: "mysticalagriculture:nature_seeds"
 			}]
+			rewards: [
+				{
+					id: "67ED22AF3D40FBED"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "16F24663BFC84395"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -5.5d
-			y: -3.0d
+			x: -15.0d
+			y: -6.0d
 			shape: "diamond"
 			dependencies: ["576ABF43FCF886B7"]
 			id: "3DDB7C8E61BA048F"
@@ -305,180 +566,367 @@
 				type: "item"
 				item: "mysticalagriculture:nether_seeds"
 			}]
+			rewards: [
+				{
+					id: "701701CAE0D1171B"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "0F1447BFF43A612E"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -4.5d
-			y: 1.5d
+			x: -14.0d
+			y: 0.5d
 			shape: "rsquare"
-			dependencies: ["576ABF43FCF886B7"]
+			dependencies: ["73350AD668200E99"]
 			id: "3384308C78D86059"
 			tasks: [{
 				id: "47EB67F67390D09C"
 				type: "item"
 				item: "mysticalagriculture:chicken_seeds"
 			}]
+			rewards: [
+				{
+					id: "40AC2CC46A03E326"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "0DFA365B6C63EDB9"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -5.5d
-			y: 3.5d
+			x: -15.0d
+			y: 2.5d
 			shape: "rsquare"
-			dependencies: ["576ABF43FCF886B7"]
+			dependencies: ["73350AD668200E99"]
 			id: "2AECDD9E2DEA708C"
 			tasks: [{
 				id: "1E4845AD1FC5216D"
 				type: "item"
 				item: "mysticalagriculture:squid_seeds"
 			}]
+			rewards: [
+				{
+					id: "1D408E6EB755F8A2"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "0498E8AC667AAC94"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
 			title: "Meow Meow I'm a Cow... NO!"
-			x: -5.5d
-			y: 2.5d
+			x: -15.0d
+			y: 1.5d
 			shape: "rsquare"
-			dependencies: ["576ABF43FCF886B7"]
+			dependencies: ["73350AD668200E99"]
 			id: "7580037DB8ADEB3C"
 			tasks: [{
 				id: "2866EA9311E575B6"
 				type: "item"
 				item: "mysticalagriculture:cow_seeds"
 			}]
+			rewards: [
+				{
+					id: "00D066F5F2269EFC"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "2AC8734439489F3C"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -5.5d
-			y: 1.5d
+			x: -15.0d
+			y: 0.5d
 			shape: "rsquare"
-			dependencies: ["576ABF43FCF886B7"]
+			dependencies: ["73350AD668200E99"]
 			id: "75D09040185B0E40"
 			tasks: [{
 				id: "4AC1F7DF47EB532C"
 				type: "item"
 				item: "mysticalagriculture:pig_seeds"
 			}]
+			rewards: [
+				{
+					id: "0659675ED867781B"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "2B560CCBF77BFF7F"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
 			title: "Beep Beep I'm a Sheep"
-			x: -4.5d
-			y: 2.5d
+			x: -14.0d
+			y: 1.5d
 			shape: "rsquare"
-			dependencies: ["576ABF43FCF886B7"]
+			dependencies: ["73350AD668200E99"]
 			id: "2C73E3C5113BF2AC"
 			tasks: [{
 				id: "745EDBA102BB6C91"
 				type: "item"
 				item: "mysticalagriculture:sheep_seeds"
 			}]
+			rewards: [
+				{
+					id: "2C0B1CD05E3C15E5"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "1F4D5FA9F3AE591D"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -4.5d
-			y: 3.5d
+			x: -14.0d
+			y: 2.5d
 			shape: "rsquare"
-			dependencies: ["576ABF43FCF886B7"]
+			dependencies: ["73350AD668200E99"]
 			id: "29AE69722AB4C75C"
 			tasks: [{
 				id: "0B7F79DE8130BAE9"
 				type: "item"
 				item: "mysticalagriculture:fish_seeds"
 			}]
+			rewards: [
+				{
+					id: "1E340982A873E895"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "5D15B62482133ADF"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -5.5d
-			y: 4.5d
+			x: -15.0d
+			y: 3.5d
 			shape: "rsquare"
-			dependencies: ["576ABF43FCF886B7"]
+			dependencies: ["73350AD668200E99"]
 			id: "092A23FDA5D50812"
 			tasks: [{
 				id: "697EBA0A6EF9183E"
 				type: "item"
 				item: "mysticalagriculture:turtle_seeds"
 			}]
+			rewards: [
+				{
+					id: "2210EFD4C8E252A1"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "4EF6DF19C18B7745"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -4.5d
-			y: 4.5d
+			x: -14.0d
+			y: 3.5d
 			shape: "rsquare"
-			dependencies: ["576ABF43FCF886B7"]
+			dependencies: ["73350AD668200E99"]
 			id: "04B6E31120663EB2"
 			tasks: [{
 				id: "180DD2AAD6C8F073"
 				type: "item"
 				item: "mysticalagriculture:slime_seeds"
 			}]
+			rewards: [
+				{
+					id: "42AE827AAB41ADC6"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "6F6C1F17DF70CE89"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -7.5d
-			y: 0.0d
+			x: -9.5d
+			y: -3.0d
 			shape: "circle"
-			dependencies: ["576ABF43FCF886B7"]
+			dependencies: ["2C9C9CB71941DC01"]
 			id: "76071C22A73A2026"
 			tasks: [{
 				id: "65F226B04C4E0440"
 				type: "item"
 				item: "mysticalagriculture:tertium_farmland"
 			}]
+			rewards: [{
+				id: "556B8FE0A696BB16"
+				type: "xp"
+				xp: 25
+			}]
 		}
 		{
-			x: -7.0d
-			y: 2.5d
+			x: -9.0d
+			y: 1.5d
 			shape: "rsquare"
-			dependencies: ["76071C22A73A2026"]
+			dependencies: ["2C9C9CB71941DC01"]
 			id: "38A77DBAD24C4B53"
 			tasks: [{
 				id: "4645F8968B0B8BE5"
 				type: "item"
 				item: "mysticalagriculture:rabbit_seeds"
 			}]
+			rewards: [
+				{
+					id: "5D6AF8B40BE48711"
+					type: "xp"
+					xp: 25
+				}
+				{
+					id: "13E9F6AFA3FA0693"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+			]
 		}
 		{
-			x: -8.0d
-			y: 3.5d
+			x: -9.5d
+			y: 2.5d
 			shape: "rsquare"
-			dependencies: ["76071C22A73A2026"]
+			dependencies: ["2C9C9CB71941DC01"]
 			id: "6A18B971C3DB83AE"
 			tasks: [{
 				id: "633406C0560295F7"
 				type: "item"
 				item: "mysticalagriculture:spider_seeds"
 			}]
+			rewards: [
+				{
+					id: "6C608AA54759D89F"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "0A3C82B3C36B09FF"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -8.0d
-			y: 2.5d
+			x: -10.0d
+			y: 1.5d
 			shape: "rsquare"
-			dependencies: ["76071C22A73A2026"]
+			dependencies: ["2C9C9CB71941DC01"]
 			id: "26A7746051A4A079"
 			tasks: [{
 				id: "4315AB4B19D55458"
 				type: "item"
 				item: "mysticalagriculture:skeleton_seeds"
 			}]
+			rewards: [
+				{
+					id: "79D6BE6D85B2CBDA"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "53B8FBD373198779"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -8.0d
-			y: 1.5d
+			x: -10.0d
+			y: 0.5d
 			shape: "rsquare"
-			dependencies: ["76071C22A73A2026"]
+			dependencies: ["2C9C9CB71941DC01"]
 			id: "155A843A562DB7C4"
 			tasks: [{
 				id: "622AAF6C554CA027"
 				type: "item"
 				item: "mysticalagriculture:zombie_seeds"
 			}]
+			rewards: [
+				{
+					id: "2F3E7095BD017FA9"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "40EE6A8B6B90CB0C"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -7.0d
-			y: 1.5d
+			x: -9.0d
+			y: 0.5d
 			shape: "rsquare"
-			dependencies: ["76071C22A73A2026"]
+			dependencies: ["2C9C9CB71941DC01"]
 			id: "7ADE214373DE135F"
 			tasks: [{
 				id: "72BC6673FB44DBB2"
 				type: "item"
 				item: "mysticalagriculture:creeper_seeds"
 			}]
+			rewards: [
+				{
+					id: "361E78548AC6C6F1"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "3CC7D35B9BCD4800"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -7.0d
-			y: -1.0d
+			x: -9.0d
+			y: -4.0d
 			shape: "diamond"
 			dependencies: ["76071C22A73A2026"]
 			id: "7A89560F303A8BE6"
@@ -487,10 +935,23 @@
 				type: "item"
 				item: "mysticalagriculture:iron_seeds"
 			}]
+			rewards: [
+				{
+					id: "4101259DB85FF47A"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "4AB006D5D57DAD29"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -8.0d
-			y: -1.0d
+			x: -10.0d
+			y: -4.0d
 			shape: "diamond"
 			dependencies: ["76071C22A73A2026"]
 			id: "56B58CAFCB707565"
@@ -499,10 +960,23 @@
 				type: "item"
 				item: "mysticalagriculture:tin_seeds"
 			}]
+			rewards: [
+				{
+					id: "1DA3A4FC29E83ABD"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "6C4A3B5DCC897DEC"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -7.5d
-			y: -1.5d
+			x: -9.5d
+			y: -4.5d
 			shape: "diamond"
 			dependencies: ["76071C22A73A2026"]
 			id: "6950FC974624C6AA"
@@ -511,10 +985,23 @@
 				type: "item"
 				item: "mysticalagriculture:silver_seeds"
 			}]
+			rewards: [
+				{
+					id: "6A9E584726E88F81"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "70DBE4B9483C3D8B"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -8.0d
-			y: -2.0d
+			x: -10.0d
+			y: -5.0d
 			shape: "diamond"
 			dependencies: ["76071C22A73A2026"]
 			id: "7361BD20A6B95D14"
@@ -523,10 +1010,23 @@
 				type: "item"
 				item: "mysticalagriculture:lead_seeds"
 			}]
+			rewards: [
+				{
+					id: "490195A29BB39EBB"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "45629DA2AEAFF6C8"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -7.0d
-			y: -2.0d
+			x: -9.0d
+			y: -5.0d
 			shape: "diamond"
 			dependencies: ["76071C22A73A2026"]
 			id: "0A8F44B9B3C8FC0F"
@@ -535,10 +1035,23 @@
 				type: "item"
 				item: "mysticalagriculture:zinc_seeds"
 			}]
+			rewards: [
+				{
+					id: "06093DF71E5D8C13"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "0B65996DBBE92C9B"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -8.0d
-			y: -3.0d
+			x: -10.0d
+			y: -6.0d
 			shape: "diamond"
 			dependencies: ["76071C22A73A2026"]
 			id: "5EE485880EA9FACF"
@@ -547,10 +1060,23 @@
 				type: "item"
 				item: "mysticalagriculture:redstone_seeds"
 			}]
+			rewards: [
+				{
+					id: "1FB4221B7C431BEF"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "67093CDD313A9388"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -7.0d
-			y: -3.0d
+			x: -9.0d
+			y: -6.0d
 			shape: "diamond"
 			dependencies: ["76071C22A73A2026"]
 			id: "02D45E3FB37ED0AD"
@@ -559,10 +1085,23 @@
 				type: "item"
 				item: "mysticalagriculture:glowstone_seeds"
 			}]
+			rewards: [
+				{
+					id: "0F4B13553FBF6A4C"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "2C5B66FF48D9E60B"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -7.5d
-			y: -3.5d
+			x: -9.5d
+			y: -6.5d
 			shape: "diamond"
 			dependencies: ["76071C22A73A2026"]
 			id: "30DF8297FEEC9F22"
@@ -571,10 +1110,23 @@
 				type: "item"
 				item: "mysticalagriculture:nether_quartz_seeds"
 			}]
+			rewards: [
+				{
+					id: "546E8A13EC87F38E"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "736DC15554CC4850"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -7.0d
-			y: -4.0d
+			x: -9.0d
+			y: -7.0d
 			shape: "diamond"
 			dependencies: ["76071C22A73A2026"]
 			id: "47045A0E8E3457C2"
@@ -583,10 +1135,23 @@
 				type: "item"
 				item: "mysticalagriculture:certus_quartz_seeds"
 			}]
+			rewards: [
+				{
+					id: "0F09266A3800C904"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "39AA29FBEF0ABB0E"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -8.0d
-			y: -4.0d
+			x: -10.0d
+			y: -7.0d
 			shape: "diamond"
 			dependencies: ["76071C22A73A2026"]
 			id: "2581B7D8E6C6E510"
@@ -595,10 +1160,23 @@
 				type: "item"
 				item: "mysticalagriculture:obsidian_seeds"
 			}]
+			rewards: [
+				{
+					id: "5BA34353811508EA"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "2924AA270CC01817"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -9.5d
-			y: -1.0d
+			x: -4.0d
+			y: -4.0d
 			shape: "diamond"
 			dependencies: ["5BC4250E4C9F803C"]
 			id: "21F654C968722841"
@@ -607,10 +1185,23 @@
 				type: "item"
 				item: "mysticalagriculture:fluorite_seeds"
 			}]
+			rewards: [
+				{
+					id: "340FBF5541CBF858"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "6F2060D741C56310"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+			]
 		}
 		{
-			x: -7.5d
-			y: -4.5d
+			x: -9.5d
+			y: -7.5d
 			shape: "diamond"
 			dependencies: ["76071C22A73A2026"]
 			id: "67AA59BD340FEC62"
@@ -619,70 +1210,147 @@
 				type: "item"
 				item: "mysticalagriculture:prismarine_seeds"
 			}]
+			rewards: [
+				{
+					id: "5E308612525261F2"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "0967B77119A4957E"
+					type: "xp"
+					xp: 25
+				}
+			]
 		}
 		{
-			x: -10.0d
-			y: 0.0d
+			x: -4.5d
+			y: -3.0d
 			shape: "circle"
-			dependencies: ["76071C22A73A2026"]
+			dependencies: ["66C52B137A4FF869"]
 			id: "5BC4250E4C9F803C"
 			tasks: [{
 				id: "19D0A5FD97D7E3E8"
 				type: "item"
 				item: "mysticalagriculture:imperium_farmland"
 			}]
+			rewards: [{
+				id: "78996299433F8E3A"
+				type: "xp"
+				xp: 50
+			}]
 		}
 		{
-			x: -10.5d
-			y: 1.5d
+			x: -5.0d
+			y: 0.5d
 			shape: "rsquare"
-			dependencies: ["5BC4250E4C9F803C"]
+			dependencies: ["66C52B137A4FF869"]
 			id: "260F9C98DC2E485B"
 			tasks: [{
 				id: "61058B1004B5C97C"
 				type: "item"
 				item: "mysticalagriculture:blaze_seeds"
 			}]
+			rewards: [
+				{
+					id: "4A50A8F0CF444B74"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "235B1BC1B80B7AD0"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+			]
 		}
 		{
-			x: -9.5d
-			y: 1.5d
+			x: -4.0d
+			y: 0.5d
 			shape: "rsquare"
-			dependencies: ["5BC4250E4C9F803C"]
+			dependencies: ["66C52B137A4FF869"]
 			id: "4F0DD86CF6E5F1B5"
 			tasks: [{
 				id: "67E85827062B8B79"
 				type: "item"
 				item: "mysticalagriculture:ghast_seeds"
 			}]
+			rewards: [
+				{
+					id: "7880F9AACD273A82"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "7BD8F77427FEB2AD"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+			]
 		}
 		{
-			x: -10.5d
-			y: 2.5d
+			x: -5.0d
+			y: 1.5d
 			shape: "rsquare"
-			dependencies: ["5BC4250E4C9F803C"]
+			dependencies: ["66C52B137A4FF869"]
 			id: "27E8ED4B5F8127F9"
 			tasks: [{
 				id: "23CCD297E830C925"
 				type: "item"
 				item: "mysticalagriculture:enderman_seeds"
 			}]
+			rewards: [
+				{
+					id: "5A5BA15966512907"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "3034B5C249788BC9"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+			]
 		}
 		{
-			x: -9.5d
-			y: 2.5d
+			x: -4.0d
+			y: 1.5d
 			shape: "rsquare"
-			dependencies: ["5BC4250E4C9F803C"]
+			dependencies: ["66C52B137A4FF869"]
 			id: "07564DBB023EE2A6"
-			tasks: [{
-				id: "0932A42E423E21A3"
-				type: "item"
-				item: "mysticalagriculture:experience_seeds"
-			}]
+			tasks: [
+				{
+					id: "0932A42E423E21A3"
+					type: "item"
+					item: "mysticalagriculture:experience_seeds"
+				}
+				{
+					id: "556BB8B22E877BC5"
+					type: "item"
+					item: "mysticalagriculture:experience_capsule"
+				}
+			]
+			rewards: [
+				{
+					id: "2F326318E6A9FF1B"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "47EBCF2D9EC16DBD"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+			]
 		}
 		{
-			x: -10.5d
-			y: -3.0d
+			x: -5.0d
+			y: -6.0d
 			shape: "diamond"
 			dependencies: ["5BC4250E4C9F803C"]
 			id: "0AF5FB1B5AA5AA11"
@@ -691,10 +1359,23 @@
 				type: "item"
 				item: "mysticalagriculture:gold_seeds"
 			}]
+			rewards: [
+				{
+					id: "4FDFC5E86E93CFA1"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "7103285B816FF259"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+			]
 		}
 		{
-			x: -10.5d
-			y: -1.0d
+			x: -5.0d
+			y: -4.0d
 			shape: "diamond"
 			dependencies: ["5BC4250E4C9F803C"]
 			id: "25D84D82DBADA0DB"
@@ -703,10 +1384,23 @@
 				type: "item"
 				item: "mysticalagriculture:nickel_seeds"
 			}]
+			rewards: [
+				{
+					id: "0227BB7E1E0AEDF1"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "6D6A96AA4DA0F0F5"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+			]
 		}
 		{
-			x: -10.0d
-			y: -1.5d
+			x: -4.5d
+			y: -4.5d
 			shape: "diamond"
 			dependencies: ["5BC4250E4C9F803C"]
 			id: "64B04D1CBC923789"
@@ -715,10 +1409,23 @@
 				type: "item"
 				item: "mysticalagriculture:lapis_lazuli_seeds"
 			}]
+			rewards: [
+				{
+					id: "03EADF991C0E3B95"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "7657863E5AE3E0B3"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+			]
 		}
 		{
-			x: -10.0d
-			y: -3.5d
+			x: -4.5d
+			y: -6.5d
 			shape: "diamond"
 			dependencies: ["5BC4250E4C9F803C"]
 			id: "222739E77C745519"
@@ -727,10 +1434,23 @@
 				type: "item"
 				item: "mysticalagriculture:osmium_seeds"
 			}]
+			rewards: [
+				{
+					id: "6728171DE1C539D4"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "49DC34DB38C2DA77"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+			]
 		}
 		{
-			x: -9.5d
-			y: -3.0d
+			x: -4.0d
+			y: -6.0d
 			shape: "diamond"
 			dependencies: ["5BC4250E4C9F803C"]
 			id: "248AEF5537E48B1A"
@@ -739,34 +1459,65 @@
 				type: "item"
 				item: "mysticalagriculture:end_seeds"
 			}]
+			rewards: [
+				{
+					id: "2A0F42A7316E845C"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "31977020FBE18521"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+			]
 		}
 		{
-			x: -12.5d
-			y: 0.0d
+			x: 0.5d
+			y: -3.0d
 			shape: "circle"
-			dependencies: ["5BC4250E4C9F803C"]
+			dependencies: ["67DBE6C59C0D9D1B"]
 			id: "48BF71269DEA1AB1"
 			tasks: [{
 				id: "7F969AA823C4157B"
 				type: "item"
 				item: "mysticalagriculture:supremium_farmland"
 			}]
+			rewards: [{
+				id: "44E76AB6B7AC8D9F"
+				type: "xp"
+				xp: 100
+			}]
 		}
 		{
-			x: -12.5d
-			y: 1.5d
+			x: 0.5d
+			y: 0.5d
 			shape: "rsquare"
-			dependencies: ["48BF71269DEA1AB1"]
+			dependencies: ["67DBE6C59C0D9D1B"]
 			id: "7CFA92CC48D1E7E3"
 			tasks: [{
 				id: "3E93D20A19EEAD09"
 				type: "item"
 				item: "mysticalagriculture:wither_skeleton_seeds"
 			}]
+			rewards: [
+				{
+					id: "7F53E76E7DE4A6D3"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "7E53D0110EBE3176"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 3627365748998225633L
+				}
+			]
 		}
 		{
-			x: -12.5d
-			y: -1.5d
+			x: 0.5d
+			y: -4.5d
 			shape: "diamond"
 			dependencies: ["48BF71269DEA1AB1"]
 			id: "5B52389583A70E66"
@@ -775,10 +1526,23 @@
 				type: "item"
 				item: "mysticalagriculture:uraninite_seeds"
 			}]
+			rewards: [
+				{
+					id: "0EF0841B27309B26"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "2CE8F5CF322C8970"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 3627365748998225633L
+				}
+			]
 		}
 		{
-			x: -12.0d
-			y: -1.0d
+			x: 1.0d
+			y: -4.0d
 			shape: "diamond"
 			dependencies: ["48BF71269DEA1AB1"]
 			id: "6A2AD67569F91F1F"
@@ -787,10 +1551,23 @@
 				type: "item"
 				item: "mysticalagriculture:diamond_seeds"
 			}]
+			rewards: [
+				{
+					id: "103D491C4092B4A0"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "39AD2E38CA2A2E39"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 3627365748998225633L
+				}
+			]
 		}
 		{
-			x: -13.0d
-			y: -1.0d
+			x: 0.0d
+			y: -4.0d
 			shape: "diamond"
 			dependencies: ["48BF71269DEA1AB1"]
 			id: "4E09BBC0BAED3440"
@@ -799,10 +1576,23 @@
 				type: "item"
 				item: "mysticalagriculture:emerald_seeds"
 			}]
+			rewards: [
+				{
+					id: "7D8DA00E4CD30BF9"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "2B95F9E9135B5ED5"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 3627365748998225633L
+				}
+			]
 		}
 		{
-			x: -13.0d
-			y: -2.0d
+			x: 0.0d
+			y: -5.0d
 			shape: "diamond"
 			dependencies: ["48BF71269DEA1AB1"]
 			id: "2B0553F307A024F7"
@@ -811,10 +1601,23 @@
 				type: "item"
 				item: "mysticalagriculture:platinum_seeds"
 			}]
+			rewards: [
+				{
+					id: "52E998698DDE1EFA"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "16A66C189272D297"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 3627365748998225633L
+				}
+			]
 		}
 		{
-			x: -12.0d
-			y: -2.0d
+			x: 1.0d
+			y: -5.0d
 			shape: "diamond"
 			dependencies: ["48BF71269DEA1AB1"]
 			id: "06A7A3FC8634D2DA"
@@ -823,10 +1626,23 @@
 				type: "item"
 				item: "mysticalagriculture:netherite_seeds"
 			}]
+			rewards: [
+				{
+					id: "4527CBF5017C52CB"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "648DAA3AAF6263D4"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 3627365748998225633L
+				}
+			]
 		}
 		{
-			x: -10.0d
-			y: -2.5d
+			x: -4.5d
+			y: -5.5d
 			shape: "diamond"
 			dependencies: ["5BC4250E4C9F803C"]
 			id: "4E7990AEBCCC3C95"
@@ -835,22 +1651,41 @@
 				type: "item"
 				item: "mysticalagriculture:uranium_seeds"
 			}]
+			rewards: [
+				{
+					id: "0745782C26D0B543"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "45778CC4E8D24605"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+			]
 		}
 		{
-			x: -15.0d
-			y: 0.0d
+			x: 5.0d
+			y: -3.5d
 			shape: "circle"
-			dependencies: ["48BF71269DEA1AB1"]
+			dependencies: ["202B1F54D3F06DAB"]
+			hide: false
 			id: "2FA6B8A1C8713DE0"
 			tasks: [{
 				id: "5A17FCC895F52C8B"
 				type: "item"
 				item: "mysticalagradditions:insanium_farmland"
 			}]
+			rewards: [{
+				id: "750518D2515C0D33"
+				type: "xp"
+				xp: 250
+			}]
 		}
 		{
-			x: -14.5d
-			y: -1.0d
+			x: 5.5d
+			y: -4.5d
 			shape: "diamond"
 			description: ["Requires a Crux (Next Quest)"]
 			dependencies: ["2FA6B8A1C8713DE0"]
@@ -860,10 +1695,23 @@
 				type: "item"
 				item: "mysticalagriculture:nether_star_seeds"
 			}]
+			rewards: [
+				{
+					id: "74F170AE3CD239B3"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 3663852184954822005L
+				}
+				{
+					id: "42FB45F90EE1E82C"
+					type: "xp"
+					xp: 250
+				}
+			]
 		}
 		{
-			x: -15.5d
-			y: -1.0d
+			x: 4.5d
+			y: -4.5d
 			shape: "diamond"
 			description: ["Requires a Crux (Next Quest)"]
 			dependencies: ["2FA6B8A1C8713DE0"]
@@ -873,12 +1721,31 @@
 				type: "item"
 				item: "mysticalagriculture:dragon_egg_seeds"
 			}]
+			rewards: [
+				{
+					id: "523D4C9B9E7EB823"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 3663852184954822005L
+				}
+				{
+					id: "3B4FCF02557044C9"
+					type: "xp"
+					xp: 250
+				}
+			]
 		}
 		{
-			x: -3.0d
-			y: 2.5d
-			shape: "rsquare"
-			description: ["Use this to make augments for the tiered armors."]
+			x: -20.199999999999996d
+			y: 2.3d
+			shape: "diamond"
+			description: [
+				"The &9Tinkering Table&r is used to upgrade &aEssence Gear&r with &dAugments&r."
+				""
+				"Augments can be made using the Infusion Altar. Just like the Essences, Augments have tiers!"
+			]
+			dependencies: ["54D6F7F8FE859729"]
+			hide: true
 			id: "6A4C49AE72E98727"
 			tasks: [
 				{
@@ -892,47 +1759,78 @@
 					item: "mysticalagriculture:unattuned_augment"
 				}
 			]
+			rewards: [
+				{
+					id: "733E64EEA73E388A"
+					type: "item"
+					item: "mysticalagriculture:unattuned_augment"
+					random_bonus: 2
+				}
+				{
+					id: "6D094DA8640BC38B"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: -2.0d
-			y: 2.5d
-			shape: "octagon"
-			description: ["This augment allows creative flight."]
-			dependencies: ["6A4C49AE72E98727"]
-			id: "50E2B7E8DA12976B"
-			tasks: [{
-				id: "695E9FEFC623D1E4"
-				type: "item"
-				item: "mysticalagriculture:flight_augment"
-			}]
-		}
-		{
-			x: 0.0d
-			y: 0.0d
-			description: ["Note: Seeds will not drop a duplicate seed when harvested."]
+			title: "&aInferium Essence&r"
+			x: -19.5d
+			y: -1.5d
+			shape: "hexagon"
+			subtitle: "&bTier 1&r"
+			description: [
+				"&dEssence&r is the starting point for all of your growing needs in Mystical Agriculture. "
+				""
+				"&eInferium Essence&r is the base tier of all essences. You can get this from mining, killing mobs, or by making seeds to grow them!"
+				""
+				"To make the bigger and better essences, you'll need to make an &9Infusion Crystal&r. "
+			]
 			id: "1CC4F8570A7A99EB"
 			tasks: [{
 				id: "667004CD0469493D"
 				type: "item"
 				item: "mysticalagriculture:inferium_essence"
 			}]
-			rewards: [{
-				id: "3D25E7ADCE8DD795"
-				type: "item"
-				item: {
-					id: "patchouli:guide_book"
-					Count: 1b
-					tag: {
-						"patchouli:book": "mysticalagriculture:guide"
+			rewards: [
+				{
+					id: "3D25E7ADCE8DD795"
+					type: "item"
+					item: {
+						id: "patchouli:guide_book"
+						Count: 1b
+						tag: {
+							"patchouli:book": "mysticalagriculture:guide"
+						}
 					}
 				}
-			}]
+				{
+					id: "4D30539341658032"
+					type: "item"
+					item: "mysticalagriculture:inferium_essence"
+					random_bonus: 2
+				}
+				{
+					id: "4E46C1C19FFFCCD0"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: 0.0d
-			y: 1.5d
-			description: ["Is required for making higher tiered essence."]
-			dependencies: ["1CC4F8570A7A99EB"]
+			title: "&9The Infusion Crystal&r"
+			x: -20.200000000000003d
+			y: 0.7999999999999998d
+			shape: "diamond"
+			description: [
+				"The &9Infusion Crystal&r is used to upgrade to higher tier &dEssences&r."
+				""
+				"To start, combining 4 Inferium with the Crystal will give you the next tier, &ePrudentium&r. 4 Prudientium Essences will upgrade to &cTertium&r, and so on."
+				""
+				"To continue your journey, you'll need to have plenty of these as they do have a durability! Eventually, you'll be able to make a crystal that doesn't break."
+			]
+			dependencies: ["54D6F7F8FE859729"]
+			hide: true
 			id: "05618FE80F2E0372"
 			tasks: [{
 				id: "255CA5B0B1870EE2"
@@ -945,88 +1843,125 @@
 					}
 				}
 			}]
+			rewards: [
+				{
+					id: "478A5AC331AFB064"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 6553016128235291313L
+				}
+				{
+					id: "5B70A04D41A9184C"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: 0.0d
-			y: 3.0d
-			description: ["Crafting essence with infinite uses!"]
-			dependencies: ["05618FE80F2E0372"]
-			id: "24F4E46FFFB0C13F"
-			tasks: [{
-				id: "53B5D5242E99AD3D"
-				type: "item"
-				item: "mysticalagriculture:master_infusion_crystal"
-			}]
-		}
-		{
-			x: 2.5d
-			y: 0.0d
+			title: "Speeding Up Growth"
+			x: -20.5d
+			y: -0.5d
 			description: [
-				"Stacking these beneath farmland will increase the speed of crops."
+				"&9Growth Accelerators&r very slightly increase the growth speed of a seed when placed directly underneath the farmland. Each tier has a range of how many blocks \"up\" it can accelerate, with Inferium being the lowest at 12."
 				""
-				"Higher tiers have a larger range, but same effect."
+				"Note: Growth Accelerators of all tiers provide the same rate of growth ticks. Higher tiers however have a larger range, so you can stack more of them below a single plant. It doesn't matter which tier you use as long as the Growth Accelerator is placed within its max range."
 			]
 			dependencies: ["1CC4F8570A7A99EB"]
+			hide: true
 			id: "4821419D44F8083F"
 			tasks: [{
 				id: "047D297988E59B6B"
 				type: "item"
 				item: "mysticalagriculture:inferium_growth_accelerator"
 			}]
+			rewards: [
+				{
+					id: "4B769BFE56697DDF"
+					type: "item"
+					item: "mysticalagriculture:inferium_essence"
+					random_bonus: 3
+				}
+				{
+					id: "06F3530E011C3671"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: 3.5d
-			y: 0.0d
-			dependencies: ["4821419D44F8083F"]
+			x: -15.5d
+			y: -0.5d
+			dependencies: ["73350AD668200E99"]
 			id: "7655E1C6C5E5469F"
 			tasks: [{
 				id: "357DFF6A72C09E2E"
 				type: "item"
 				item: "mysticalagriculture:prudentium_growth_accelerator"
 			}]
+			rewards: [{
+				id: "7E8581BE5D310EFD"
+				type: "xp"
+				xp: 10
+			}]
 		}
 		{
-			x: 4.5d
-			y: 0.0d
-			dependencies: ["7655E1C6C5E5469F"]
+			x: -10.5d
+			y: -0.5d
+			dependencies: ["2C9C9CB71941DC01"]
 			id: "077B2D62FA7650FB"
 			tasks: [{
 				id: "21BCED1462115F52"
 				type: "item"
 				item: "mysticalagriculture:tertium_growth_accelerator"
 			}]
+			rewards: [{
+				id: "13C0DE1B6E41A5A4"
+				type: "xp"
+				xp: 25
+			}]
 		}
 		{
-			x: 5.5d
-			y: 0.0d
-			dependencies: ["077B2D62FA7650FB"]
+			x: -5.5d
+			y: -0.5d
+			dependencies: ["66C52B137A4FF869"]
 			id: "06EAA74E0A10CBB6"
 			tasks: [{
 				id: "77C281598A060103"
 				type: "item"
 				item: "mysticalagriculture:imperium_growth_accelerator"
 			}]
+			rewards: [{
+				id: "3ED2B39F0EC37469"
+				type: "xp"
+				xp: 50
+			}]
 		}
 		{
-			x: 6.5d
-			y: 0.0d
-			dependencies: ["06EAA74E0A10CBB6"]
+			x: -0.5d
+			y: -0.5d
+			dependencies: ["67DBE6C59C0D9D1B"]
 			id: "3E555B364FD88B43"
 			tasks: [{
 				id: "7572E0FF1D153196"
 				type: "item"
 				item: "mysticalagriculture:supremium_growth_accelerator"
 			}]
+			rewards: [{
+				id: "772E85D99E94298D"
+				type: "xp"
+				xp: 100
+			}]
 		}
 		{
-			x: 2.5d
-			y: -1.0d
+			x: -20.5d
+			y: -2.5d
 			description: [
-				"Using this near or on crops will help the crops grow faster!"
+				"The &aWatering Can&r is used to increase the speed that crops grow. Higher tiers have a larger area of effect. To use this, fill it up with some water by right clicking some water, then hold right click near your crops to water them!"
 				""
-				"Higher tiers have a larger area of effect."
+				"Tip: You can shift-right click while looking in the air with the watering can to enable auto-watering."
 			]
 			dependencies: ["1CC4F8570A7A99EB"]
+			hide: true
 			id: "62D04566426DD979"
 			tasks: [{
 				id: "00DC18C2F39EC0AC"
@@ -1040,11 +1975,24 @@
 					}
 				}
 			}]
+			rewards: [
+				{
+					id: "04B6A213D9683D4D"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 6553016128235291313L
+				}
+				{
+					id: "5A72EF8E966E1E23"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: 3.5d
-			y: -1.0d
-			dependencies: ["62D04566426DD979"]
+			x: -15.5d
+			y: -2.5d
+			dependencies: ["73350AD668200E99"]
 			id: "1AC3485AB2EA13E5"
 			tasks: [{
 				id: "0CBE6C91D28E45B1"
@@ -1058,11 +2006,24 @@
 					}
 				}
 			}]
+			rewards: [
+				{
+					id: "5E2106AE83DADFB2"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "3A26CE9DB27C9272"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+			]
 		}
 		{
-			x: 4.5d
-			y: -1.0d
-			dependencies: ["1AC3485AB2EA13E5"]
+			x: -10.5d
+			y: -2.5d
+			dependencies: ["2C9C9CB71941DC01"]
 			id: "69D8F6483DACD930"
 			tasks: [{
 				id: "0CA99B2609E73E80"
@@ -1076,11 +2037,24 @@
 					}
 				}
 			}]
+			rewards: [
+				{
+					id: "16A3731766EBE630"
+					type: "xp"
+					xp: 25
+				}
+				{
+					id: "672A93BE625F2C9F"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+			]
 		}
 		{
-			x: 5.5d
-			y: -1.0d
-			dependencies: ["69D8F6483DACD930"]
+			x: -5.5d
+			y: -2.5d
+			dependencies: ["66C52B137A4FF869"]
 			id: "20CA94E3263FCA5E"
 			tasks: [{
 				id: "4DC4C2C45A241BBB"
@@ -1094,11 +2068,30 @@
 					}
 				}
 			}]
+			rewards: [
+				{
+					id: "4313254414219D46"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "6F6A5B3CF244D1CA"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "442AAC4C7285EC07"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+			]
 		}
 		{
-			x: 6.5d
-			y: -1.0d
-			dependencies: ["20CA94E3263FCA5E"]
+			x: -0.5d
+			y: -2.5d
+			dependencies: ["67DBE6C59C0D9D1B"]
 			id: "475B63AF0E87E318"
 			tasks: [{
 				id: "4A4E7C928F5407C0"
@@ -1112,142 +2105,264 @@
 					}
 				}
 			}]
+			rewards: [
+				{
+					id: "4FEFFD1453BCBD94"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "568194B172AA9E20"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 3627365748998225633L
+				}
+			]
 		}
 		{
-			x: 2.5d
-			y: 1.0d
-			description: [
-				"This can turn any extra seeds you have into their respective essence, at the cost of fuel."
-				""
-				"Higher tiers are faster."
-			]
+			x: -18.5d
+			y: -0.5d
+			description: ["Have too many extra seeds? These will convert the extra seeds to the respective Essence, at the cost of fuel. These can also be upgraded!"]
 			dependencies: ["1CC4F8570A7A99EB"]
+			hide: true
 			id: "722B66145690D56B"
 			tasks: [{
 				id: "54834BF18B95D535"
 				type: "item"
 				item: "mysticalagriculture:inferium_reprocessor"
 			}]
+			rewards: [
+				{
+					id: "6C3560523C52C92A"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 6553016128235291313L
+				}
+				{
+					id: "5E747B8CA8EEF100"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: 3.5d
-			y: 1.0d
-			dependencies: ["722B66145690D56B"]
+			x: -13.5d
+			y: -0.5d
+			dependencies: ["73350AD668200E99"]
 			id: "19092706A5192F5E"
 			tasks: [{
 				id: "7C20C86A044B8B9B"
 				type: "item"
 				item: "mysticalagriculture:prudentium_reprocessor"
 			}]
+			rewards: [
+				{
+					id: "1A5C1009CA9364EA"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "031ADAE1F8E4CC8C"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+			]
 		}
 		{
-			x: 4.5d
-			y: 1.0d
-			dependencies: ["19092706A5192F5E"]
+			x: -8.5d
+			y: -0.5d
+			dependencies: ["2C9C9CB71941DC01"]
 			id: "7012244236825F79"
 			tasks: [{
 				id: "3CB4C9C081DFADF3"
 				type: "item"
 				item: "mysticalagriculture:tertium_reprocessor"
 			}]
+			rewards: [
+				{
+					id: "59C3C79358C46909"
+					type: "xp"
+					xp: 25
+				}
+				{
+					id: "0A0D594455230F9A"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+			]
 		}
 		{
-			x: 5.5d
-			y: 1.0d
-			dependencies: ["7012244236825F79"]
+			x: -3.5d
+			y: -0.5d
+			dependencies: ["66C52B137A4FF869"]
 			id: "77EB0A0A5E5A2F32"
 			tasks: [{
 				id: "7C671AA8A5D65A54"
 				type: "item"
 				item: "mysticalagriculture:imperium_reprocessor"
 			}]
+			rewards: [
+				{
+					id: "0E25747848E492C0"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "595C5ABBF966821A"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+			]
 		}
 		{
-			x: 6.5d
-			y: 1.0d
-			dependencies: ["77EB0A0A5E5A2F32"]
+			x: 1.5d
+			y: -0.5d
+			dependencies: ["67DBE6C59C0D9D1B"]
 			id: "1BC3146A1CDD1C79"
 			tasks: [{
 				id: "2CF4F257B61EBB53"
 				type: "item"
 				item: "mysticalagriculture:supremium_reprocessor"
 			}]
+			rewards: [
+				{
+					id: "2F1274F36B1498BD"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "1FDD1C79579974B6"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 3627365748998225633L
+				}
+			]
 		}
 		{
-			x: 2.5d
-			y: 2.0d
+			x: -18.5d
+			y: -2.5d
 			description: [
 				"Better than a golden apple, and a tasty snack!"
 				""
 				"Higher tiers give more hunger and saturation, as well as more buffs."
 			]
 			dependencies: ["1CC4F8570A7A99EB"]
+			hide: true
 			id: "1F88C697817A7680"
 			tasks: [{
 				id: "51547F271EAC0A87"
 				type: "item"
 				item: "mysticalagradditions:inferium_apple"
 			}]
+			rewards: [
+				{
+					id: "5CCA33558E177F51"
+					type: "item"
+					item: "mysticalagriculture:inferium_essence"
+					random_bonus: 3
+				}
+				{
+					id: "0CCC0CB700A57992"
+					type: "xp"
+					xp: 10
+				}
+			]
 		}
 		{
-			x: 3.5d
-			y: 2.0d
-			dependencies: ["1F88C697817A7680"]
+			x: -13.5d
+			y: -2.5d
+			dependencies: ["73350AD668200E99"]
 			id: "3BB3AA6C29285837"
 			tasks: [{
 				id: "50EED9493818859D"
 				type: "item"
 				item: "mysticalagradditions:prudentium_apple"
 			}]
+			rewards: [{
+				id: "61D04CE0E2195B37"
+				type: "xp"
+				xp: 10
+			}]
 		}
 		{
-			x: 4.5d
-			y: 2.0d
-			dependencies: ["3BB3AA6C29285837"]
+			x: -8.5d
+			y: -2.5d
+			dependencies: ["2C9C9CB71941DC01"]
 			id: "5F6ACDE014A61F46"
 			tasks: [{
 				id: "7991C1D054311F8C"
 				type: "item"
 				item: "mysticalagradditions:tertium_apple"
 			}]
+			rewards: [{
+				id: "00D7A0D35FE36750"
+				type: "xp"
+				xp: 25
+			}]
 		}
 		{
-			x: 5.5d
-			y: 2.0d
-			dependencies: ["5F6ACDE014A61F46"]
+			x: -3.5d
+			y: -2.5d
+			dependencies: ["66C52B137A4FF869"]
 			id: "212EF8601746C500"
 			tasks: [{
 				id: "6B6B34B77A5563FC"
 				type: "item"
 				item: "mysticalagradditions:imperium_apple"
 			}]
+			rewards: [{
+				id: "237BA662FCE263A8"
+				type: "xp"
+				xp: 50
+			}]
 		}
 		{
-			x: 6.5d
-			y: 2.0d
-			dependencies: ["212EF8601746C500"]
+			x: 1.5d
+			y: -2.5d
+			dependencies: ["67DBE6C59C0D9D1B"]
 			id: "1C4ABF4518638A82"
 			tasks: [{
 				id: "100405DB15F68EE1"
 				type: "item"
 				item: "mysticalagradditions:supremium_apple"
 			}]
+			rewards: [{
+				id: "11C424736B860466"
+				type: "xp"
+				xp: 100
+			}]
 		}
 		{
-			x: 7.5d
-			y: 2.0d
-			dependencies: ["1C4ABF4518638A82"]
+			x: 5.0d
+			y: 0.5d
+			dependencies: ["202B1F54D3F06DAB"]
 			id: "1F7591DB6D8EC1E7"
 			tasks: [{
 				id: "0458D76584A3A6DB"
 				type: "item"
 				item: "mysticalagradditions:insanium_apple"
 			}]
+			rewards: [{
+				id: "39D16F8A351DAC73"
+				type: "xp"
+				xp: 250
+			}]
 		}
 		{
-			x: 2.5d
-			y: -2.0d
+			title: "&aEssence Gear&r"
+			x: -18.0d
+			y: -1.5d
+			description: [
+				"To start your journey making &aEssence Gear&r, you'll need to make the Inferium Armor first."
+				""
+				"This gear can be upgraded to higher tiers, just like the Essences. You can also &9Augment&r them with the &bTinkering Table&r!"
+			]
+			hide_dependency_lines: false
 			dependencies: ["1CC4F8570A7A99EB"]
+			hide: true
 			id: "2A7E3F2CD335EAD0"
 			tasks: [
 				{
@@ -1295,11 +2410,31 @@
 					}
 				}
 			]
+			rewards: [
+				{
+					id: "6EBB22AE043BD584"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 6553016128235291313L
+				}
+				{
+					id: "0416BE831999470A"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "6B8951013168741F"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+			]
 		}
 		{
-			x: 3.5d
-			y: -2.0d
-			dependencies: ["2A7E3F2CD335EAD0"]
+			title: "&2Prudentium Armor&r"
+			x: -13.0d
+			y: -1.5d
+			dependencies: ["73350AD668200E99"]
 			dependency_requirement: "all_started"
 			id: "4F137DB561F45306"
 			tasks: [
@@ -1348,11 +2483,31 @@
 					}
 				}
 			]
+			rewards: [
+				{
+					id: "18D9C501E9108110"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "701C8867B5051796"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+				{
+					id: "5A9917547D4AEEC5"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+			]
 		}
 		{
-			x: 4.5d
-			y: -2.0d
-			dependencies: ["4F137DB561F45306"]
+			title: "&cTertium Armor"
+			x: -8.0d
+			y: -1.5d
+			dependencies: ["2C9C9CB71941DC01"]
 			dependency_requirement: "all_started"
 			id: "15D764CAF047EA7A"
 			tasks: [
@@ -1401,11 +2556,31 @@
 					}
 				}
 			]
+			rewards: [
+				{
+					id: "27FF161346C47352"
+					type: "xp"
+					xp: 25
+				}
+				{
+					id: "2036223FAF92D1C3"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "587980D021D299C0"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+			]
 		}
 		{
-			x: 5.5d
-			y: -2.0d
-			dependencies: ["15D764CAF047EA7A"]
+			title: "&9Imperium Armor"
+			x: -3.0d
+			y: -1.5d
+			dependencies: ["66C52B137A4FF869"]
 			dependency_requirement: "all_started"
 			id: "7D43016926E77150"
 			tasks: [
@@ -1454,11 +2629,31 @@
 					}
 				}
 			]
+			rewards: [
+				{
+					id: "5154E725372B77F2"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "0BAE1C58BF3FD0C7"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+				{
+					id: "77C483C2396DC415"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+			]
 		}
 		{
-			x: 6.5d
-			y: -2.0d
-			dependencies: ["7D43016926E77150"]
+			title: "&4Supremium Armor"
+			x: 2.0d
+			y: -1.5d
+			dependencies: ["67DBE6C59C0D9D1B"]
 			dependency_requirement: "all_started"
 			id: "5B1E0E3E876339E7"
 			tasks: [
@@ -1507,10 +2702,29 @@
 					}
 				}
 			]
+			rewards: [
+				{
+					id: "7F1DC169F853D19D"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "1E73671D612180D6"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 3627365748998225633L
+				}
+				{
+					id: "4ED2F900C6900BC1"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+			]
 		}
 		{
-			x: -14.5d
-			y: -2.0d
+			x: 5.5d
+			y: -5.5d
 			shape: "hexagon"
 			description: ["Place this under the soil to allow Nether Star Seeds to grow."]
 			dependencies: ["4A96A0456680837C"]
@@ -1520,10 +2734,15 @@
 				type: "item"
 				item: "mysticalagradditions:nether_star_crux"
 			}]
+			rewards: [{
+				id: "433A4B914A5FA642"
+				type: "xp"
+				xp: 250
+			}]
 		}
 		{
-			x: -15.5d
-			y: -2.0d
+			x: 4.5d
+			y: -5.5d
 			shape: "hexagon"
 			description: ["Place this under the soil to allow Dragon Egg Seeds to grow."]
 			dependencies: ["6AB1C7B6251FE9F5"]
@@ -1532,6 +2751,1071 @@
 				id: "725AA849F27E509F"
 				type: "item"
 				item: "mysticalagradditions:dragon_egg_crux"
+			}]
+			rewards: [{
+				id: "7A9B43198D240FCA"
+				type: "xp"
+				xp: 250
+			}]
+		}
+		{
+			title: "&2Prudentium Essence&r"
+			x: -14.5d
+			y: -1.5d
+			shape: "hexagon"
+			subtitle: "&bTier 2&r"
+			description: ["This is the Tier 2 Essence, made by combining 4 Inferium together with an Infusion Crystal."]
+			hide_dependency_lines: true
+			dependencies: ["1CC4F8570A7A99EB"]
+			hide: true
+			size: 1.25d
+			id: "73350AD668200E99"
+			tasks: [{
+				id: "4B2621F8D8FA7CA7"
+				type: "item"
+				item: "mysticalagriculture:prudentium_essence"
+			}]
+			rewards: [
+				{
+					id: "3567491765DBBD85"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "721779A7E4B65713"
+					type: "item"
+					item: "mysticalagriculture:prudentium_essence"
+					random_bonus: 1
+				}
+			]
+		}
+		{
+			title: "&cTertium Essence"
+			x: -9.5d
+			y: -1.5d
+			shape: "hexagon"
+			subtitle: "&bTier 3"
+			hide_dependency_lines: true
+			dependencies: ["73350AD668200E99"]
+			hide: true
+			size: 1.5d
+			id: "2C9C9CB71941DC01"
+			tasks: [{
+				id: "6A85B770B8EA032B"
+				type: "item"
+				item: "mysticalagriculture:tertium_essence"
+			}]
+			rewards: [
+				{
+					id: "08F8F43CD2DE7802"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+				{
+					id: "16EB669025917F77"
+					type: "xp"
+					xp: 25
+				}
+			]
+		}
+		{
+			title: "&9Imperium Essence"
+			x: -4.5d
+			y: -1.5d
+			shape: "hexagon"
+			subtitle: "&bTier 4"
+			hide_dependency_lines: true
+			dependencies: ["2C9C9CB71941DC01"]
+			hide: true
+			size: 1.5d
+			id: "66C52B137A4FF869"
+			tasks: [{
+				id: "4BEC4730588463FE"
+				type: "item"
+				item: "mysticalagriculture:imperium_essence"
+			}]
+			rewards: [
+				{
+					id: "331775C656F9D2F2"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "17505B781B07AFBF"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+			]
+		}
+		{
+			title: "&4Supremium Essence"
+			x: 0.5d
+			y: -1.5d
+			shape: "hexagon"
+			subtitle: "&bTier 5"
+			hide_dependency_lines: true
+			dependencies: ["66C52B137A4FF869"]
+			hide: true
+			size: 2.0d
+			id: "67DBE6C59C0D9D1B"
+			tasks: [{
+				id: "247349D4951C789F"
+				type: "item"
+				item: "mysticalagriculture:supremium_essence"
+			}]
+			rewards: [
+				{
+					id: "4A66ACCE4E9ABC7E"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+				{
+					id: "51F17AE5A158CE62"
+					type: "xp"
+					xp: 100
+				}
+			]
+		}
+		{
+			title: "&1Insanium Essence"
+			x: 5.0d
+			y: -1.5d
+			shape: "hexagon"
+			subtitle: "&bTier 6"
+			hide_dependency_lines: true
+			dependencies: ["67DBE6C59C0D9D1B"]
+			hide: true
+			size: 2.5d
+			id: "202B1F54D3F06DAB"
+			tasks: [{
+				id: "179DC208291D3C90"
+				type: "item"
+				item: "mysticalagradditions:insanium_essence"
+			}]
+			rewards: [
+				{
+					id: "10711EA8BA63D6C2"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+				{
+					id: "15CDEF693935DDC7"
+					type: "xp"
+					xp: 250
+				}
+			]
+		}
+		{
+			title: "&cAwakened Watering&r"
+			x: 2.0d
+			y: 5.0d
+			dependencies: ["7A103577EAE7B3F1"]
+			id: "3A4B5A9B432576AD"
+			tasks: [{
+				id: "2B146AB565D648AF"
+				type: "item"
+				item: {
+					id: "mysticalagriculture:awakened_supremium_watering_can"
+					Count: 1b
+					tag: {
+						Water: 0b
+						Active: 0b
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "7337814EDF6B0BD4"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "480A62513691C12A"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+			]
+		}
+		{
+			title: "&cAwakened Armor&r"
+			x: -1.0d
+			y: 5.0d
+			dependencies: ["7A103577EAE7B3F1"]
+			id: "685C4A646E092A82"
+			tasks: [
+				{
+					id: "6A66020F75FB0CDB"
+					type: "item"
+					item: {
+						id: "mysticalagriculture:awakened_supremium_helmet"
+						Count: 1b
+						tag: {
+							Damage: 0
+						}
+					}
+				}
+				{
+					id: "33823BEEA08AFE8F"
+					type: "item"
+					item: {
+						id: "mysticalagriculture:awakened_supremium_chestplate"
+						Count: 1b
+						tag: {
+							Damage: 0
+						}
+					}
+				}
+				{
+					id: "5F4BDE8731B7CA86"
+					type: "item"
+					item: {
+						id: "mysticalagriculture:awakened_supremium_leggings"
+						Count: 1b
+						tag: {
+							Damage: 0
+						}
+					}
+				}
+				{
+					id: "1B5875E635B468A2"
+					type: "item"
+					item: {
+						id: "mysticalagriculture:awakened_supremium_boots"
+						Count: 1b
+						tag: {
+							Damage: 0
+						}
+					}
+				}
+			]
+			rewards: [
+				{
+					id: "782618367E8FCD36"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "498E07346770D4CB"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+				{
+					id: "0A337E0C343C74BD"
+					type: "item"
+					item: "mysticalagradditions:insanium_essence"
+				}
+			]
+		}
+		{
+			title: "&aEssence Tools and Weapons&r"
+			x: -21.0d
+			y: -1.5d
+			description: [
+				"Starting with Inferium Essence, you can create ingots to make both Essence &9Tools&r and &9Armor&r."
+				""
+				"Essence tools can be upgraded to higher tiers, and just like the Armor, they can be &5Augmented&r in the &3Tinkering Table&r."
+			]
+			dependencies: ["1CC4F8570A7A99EB"]
+			hide: true
+			id: "4EF5DE3FBA2A7AE3"
+			tasks: [{
+				id: "174B6F296A7E3F2D"
+				type: "item"
+				title: "Inferium Tools and Weapons"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "mysticalagriculture:inferium_sword"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:inferium_pickaxe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:inferium_shovel"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:inferium_axe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:inferium_hoe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:inferium_bow"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:inferium_crossbow"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:inferium_shears"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:inferium_fishing_rod"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:inferium_sickle"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:inferium_scythe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagradditions:inferium_paxel"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "633E7E06191C60B8"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 6553016128235291313L
+				}
+				{
+					id: "65AC8A0E2919DC9B"
+					type: "xp"
+					xp: 10
+				}
+			]
+		}
+		{
+			title: "&2Prudentium Tools and Weapons"
+			x: -16.0d
+			y: -1.5d
+			dependencies: ["73350AD668200E99"]
+			id: "3339445194568D77"
+			tasks: [{
+				id: "7D4224D89E799A14"
+				type: "item"
+				title: "Prudentium Tools and Weapons"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "mysticalagriculture:prudentium_sword"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:prudentium_pickaxe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:prudentium_shovel"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:prudentium_axe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:prudentium_hoe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:prudentium_bow"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:prudentium_crossbow"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:prudentium_fishing_rod"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:prudentium_shears"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:prudentium_sickle"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:prudentium_scythe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagradditions:prudentium_paxel"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "464777A63727DA2F"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "2A954390167C7337"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 2427872771413920777L
+				}
+			]
+		}
+		{
+			title: "&cTertium Tools and Weapons"
+			x: -11.0d
+			y: -1.5d
+			dependencies: ["2C9C9CB71941DC01"]
+			id: "1E414D285E7A5FE2"
+			tasks: [{
+				id: "76EEDB393CB4FF6F"
+				type: "item"
+				title: "Tertium Tools and Weapons"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "mysticalagriculture:tertium_sword"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:tertium_pickaxe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:tertium_shovel"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:tertium_axe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:tertium_hoe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:tertium_bow"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:tertium_crossbow"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:tertium_shears"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:tertium_fishing_rod"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:tertium_sickle"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:tertium_scythe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagradditions:tertium_paxel"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "0E76ECFEB8F11E6A"
+					type: "xp"
+					xp: 25
+				}
+				{
+					id: "03D317FED0628032"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+			]
+		}
+		{
+			title: "&9Imperium Tools and Weapons"
+			x: -6.0d
+			y: -1.5d
+			dependencies: ["66C52B137A4FF869"]
+			id: "67DDFA6FB1F9EECA"
+			tasks: [{
+				id: "1BE8E3CD2EAA7A64"
+				type: "item"
+				title: "Imperium Tools and Weapons"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "mysticalagriculture:imperium_sword"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:imperium_pickaxe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:imperium_shovel"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:imperium_axe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:imperium_hoe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:imperium_bow"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:imperium_crossbow"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:imperium_shears"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:imperium_fishing_rod"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:imperium_sickle"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagriculture:imperium_scythe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "mysticalagradditions:imperium_paxel"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "02719D739C373FD5"
+					type: "xp"
+					xp: 50
+				}
+				{
+					id: "7DD46ABAFEDCFAA1"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7746042620417867758L
+				}
+				{
+					id: "383F47826DB20DF3"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 7059507240202337975L
+				}
+			]
+		}
+		{
+			title: "&4Supremium Tools and Weapons"
+			x: -1.0d
+			y: -1.5d
+			dependencies: ["67DBE6C59C0D9D1B"]
+			id: "30E9255DEC69C061"
+			tasks: [{
+				id: "3083D90A0F79A772"
+				type: "item"
+				title: "Supremium Tools and Weapons"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "mysticalagriculture:supremium_sword"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:supremium_pickaxe"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:supremium_shovel"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:supremium_axe"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:supremium_hoe"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:supremium_bow"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:supremium_crossbow"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:supremium_shears"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:supremium_fishing_rod"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:supremium_sickle"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:supremium_scythe"
+								Count: 1b
+							}
+							{
+								id: "mysticalagradditions:supremium_paxel"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "2CB8FCF5EE19919C"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "137EABC171001414"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 3627365748998225633L
+				}
+			]
+		}
+		{
+			title: "&cAwakened Tools and Weapons&r"
+			x: 0.5d
+			y: 5.5d
+			dependencies: ["7A103577EAE7B3F1"]
+			id: "5A58D4B25C9CB757"
+			tasks: [{
+				id: "343438DEFC6E307A"
+				type: "item"
+				title: "Awakened Supremium Tools and Weapons"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "mysticalagriculture:awakened_supremium_sword"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:awakened_supremium_pickaxe"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:awakened_supremium_shovel"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:awakened_supremium_axe"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:awakened_supremium_hoe"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:awakened_supremium_bow"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:awakened_supremium_crossbow"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:awakened_supremium_shears"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:awakened_supremium_fishing_rod"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:awakened_supremium_sickle"
+								Count: 1b
+							}
+							{
+								id: "mysticalagriculture:awakened_supremium_scythe"
+								Count: 1b
+							}
+							{
+								id: "mysticalagradditions:awakened_supremium_paxel"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "7B0AD2F72CBB422E"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "19C7CA5B965CA8B1"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+			]
+		}
+		{
+			title: "&cAwakened Supremium Essence"
+			icon: "mysticalagriculture:awakened_supremium_essence"
+			x: 0.5d
+			y: 3.5d
+			shape: "octagon"
+			subtitle: "&bTier: Awakened"
+			hide_dependency_lines: false
+			dependencies: [
+				"67DBE6C59C0D9D1B"
+				"33D23C65E7274A8F"
+				"1CF8263756EE8F2A"
+			]
+			hide: true
+			size: 2.5d
+			id: "7A103577EAE7B3F1"
+			tasks: [{
+				id: "3DB6441F3AE36AAB"
+				type: "item"
+				item: "mysticalagriculture:awakened_supremium_block"
+			}]
+			rewards: [
+				{
+					id: "75DBEA9D628C46DD"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "0F431936FBC2122B"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+				{
+					id: "2C6F12251219F471"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+			]
+		}
+		{
+			x: 7.0d
+			y: -1.5d
+			shape: "gear"
+			description: ["This special essence is used for making the &6ATM Star&r."]
+			dependencies: ["202B1F54D3F06DAB"]
+			id: "7AD83A26A52C0983"
+			tasks: [{
+				id: "2B334E5C8E52BAF5"
+				type: "item"
+				item: "mysticalagradditions:creative_essence"
+			}]
+			rewards: [
+				{
+					id: "0353EB8E142438F7"
+					type: "xp"
+					xp: 250
+				}
+				{
+					id: "07EE544812B65419"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 3663852184954822005L
+				}
+				{
+					id: "2FCBE7F7C07D6BFA"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+			]
+		}
+		{
+			title: "&dThe Awakening&r"
+			x: -0.5d
+			y: 1.5d
+			shape: "hexagon"
+			description: [
+				"To awaken your Supremium Essence, you'll need to create a new Altar and 4 new Pedestals, as well as a new type of pedestal called the &cEssence Vessel&r."
+				""
+				"The Essence Vessels will require the starter Element Essences to fill: Fire, Water, Earth, and Air."
+			]
+			hide_dependency_lines: false
+			dependencies: ["67DBE6C59C0D9D1B"]
+			id: "33D23C65E7274A8F"
+			tasks: [
+				{
+					id: "18EF4F05A89E6B62"
+					type: "item"
+					item: "mysticalagriculture:awakening_altar"
+				}
+				{
+					id: "7BFAF64BFE1A537D"
+					type: "item"
+					item: "mysticalagriculture:awakening_pedestal"
+					count: 4L
+				}
+				{
+					id: "0B83A9AFF8703E87"
+					type: "item"
+					item: "mysticalagriculture:essence_vessel"
+					count: 4L
+				}
+			]
+			rewards: [{
+				id: "611CFC9E45F875FA"
+				type: "xp"
+				xp: 100
+			}]
+		}
+		{
+			title: "&5Cognizant Dust"
+			x: 1.5d
+			y: 1.5d
+			shape: "hexagon"
+			description: ["This special &eDust&r is dropped from the Wither and the Ender Dragon when killed by an &dEssence Weapon&r enchanted with &dMystical Enlightenment&r."]
+			hide_dependency_lines: false
+			dependencies: ["67DBE6C59C0D9D1B"]
+			hide: true
+			id: "1CF8263756EE8F2A"
+			tasks: [{
+				id: "4B044D41247AC672"
+				type: "item"
+				item: "mysticalagriculture:cognizant_dust"
+			}]
+			rewards: [
+				{
+					id: "08A14FAD1B4AADD0"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "0523DBFE18DDB5B8"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 5325714992629626565L
+				}
+			]
+		}
+		{
+			title: "Prosperity Shards"
+			x: -19.5d
+			y: 1.5d
+			shape: "hexagon"
+			description: [
+				"&bProsperity Shards&r are used as one of the main crafting mats for several of the recipes in Mystical Agriculture, like seeds, ingots, and more."
+				""
+				"You'll find these from mining!"
+			]
+			dependencies: ["1CC4F8570A7A99EB"]
+			hide: true
+			id: "54D6F7F8FE859729"
+			tasks: [{
+				id: "63E738B944DC0915"
+				type: "item"
+				item: "mysticalagriculture:prosperity_shard"
+			}]
+			rewards: [{
+				id: "6C00F85D73FBE858"
+				type: "xp"
+				xp: 10
 			}]
 		}
 	]

--- a/config/ftbquests/quests/chapters/storage.snbt
+++ b/config/ftbquests/quests/chapters/storage.snbt
@@ -167,16 +167,23 @@
 			]
 		}
 		{
-			title: "Vanilla Chest"
+			title: "\"Vanilla\" Chest"
 			x: -9.0d
 			y: -1.5d
 			subtitle: "The Starting Chest"
+			description: ["Just like a vanilla chest, but has a slot for a Storage Upgrade!"]
 			dependencies: ["563CFA1EF74E52E9"]
 			id: "5E4BC0F59C90433A"
 			tasks: [{
-				id: "3C4AC12A7BCA9299"
+				id: "5241AA0EF3C2EA94"
 				type: "item"
-				item: "minecraft:chest"
+				item: {
+					id: "sophisticatedstorage:chest"
+					Count: 1b
+					tag: {
+						woodType: "oak"
+					}
+				}
 			}]
 			rewards: [
 				{
@@ -1706,7 +1713,7 @@
 			y: 0.0d
 			subtitle: "Utility for Chests"
 			description: [
-				"To save you from having this &o entire quest section &r covered with filter upgrades, take a look at the Sophisticated Backpack upgrades."
+				"To save you from having this &oentire quest section&r covered with filter upgrades, take a look at the Sophisticated Backpack upgrades."
 				""
 				"You'll need to make the Sophisticated Storage equivalent, but they function about the same."
 			]

--- a/config/ftbquests/quests/chapters/thermal_expansion.snbt
+++ b/config/ftbquests/quests/chapters/thermal_expansion.snbt
@@ -1,0 +1,1775 @@
+{
+	id: "658721DF03EC997D"
+	group: "2B51AC12041E3F89"
+	order_index: 4
+	filename: "thermal_expansion"
+	title: "Thermal Series"
+	icon: "thermal:machine_frame"
+	default_quest_shape: ""
+	default_hide_dependency_lines: false
+	quests: [
+		{
+			title: "Welcome to the &9Thermal Series&r!"
+			icon: "thermal:upgrade_augment_3"
+			x: -4.5d
+			y: 0.0d
+			shape: "square"
+			description: ["Thermal Series is a modular series of mods that adds a content-rich blend of magic and technology to your Minecraft experience!"]
+			size: 1.5d
+			id: "2C50B0E024C3D92E"
+			tasks: [{
+				id: "37547F63C72EED17"
+				type: "item"
+				item: "alltheores:raw_tin"
+			}]
+			rewards: [
+				{
+					id: "184363B38B8B2CBA"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "009C332DA938512C"
+					type: "item"
+					item: {
+						id: "patchouli:guide_book"
+						Count: 1b
+						tag: {
+							"patchouli:book": "thermal:guidebook"
+						}
+					}
+				}
+			]
+		}
+		{
+			title: "The Redstone Furnace"
+			x: 1.5d
+			y: 0.0d
+			subtitle: "Powered Furnace"
+			description: [
+				"The Redstone Furnace uses RF/FE instead of Coal to smelt items."
+				""
+				"Like all machines in the Thermal Series, this machine can be upgraded with augments to increase the speed of each process."
+			]
+			dependencies: ["5F385CBA98795C62"]
+			id: "22BC123D486CC3E3"
+			tasks: [{
+				id: "288B38C43A7C6D48"
+				type: "item"
+				item: "thermal:machine_furnace"
+			}]
+			rewards: [{
+				id: "47FB9A5E8CA0DEBF"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 4084485630345500261L
+			}]
+		}
+		{
+			x: 3.5d
+			y: 0.0d
+			subtitle: "Breaks Ores into Dusts"
+			description: ["The Pulverizer breaks raw ores into dusts, and also has a 25% chance to create an extra dust."]
+			dependencies: ["22BC123D486CC3E3"]
+			id: "55C8DD9A754545BD"
+			tasks: [{
+				id: "06665E87CB134F3C"
+				type: "item"
+				item: "thermal:machine_pulverizer"
+			}]
+			rewards: [{
+				id: "3A6A6FD904C5D807"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 4084485630345500261L
+			}]
+		}
+		{
+			x: 5.5d
+			y: 0.0d
+			subtitle: "The Alloy Maker"
+			description: [
+				"The Induction Furnace combines materials into new alloys."
+				""
+				"This is also useful when smelting Ancient Debris into Netherite Scraps."
+			]
+			dependencies: ["55C8DD9A754545BD"]
+			id: "452F51995AD0461C"
+			tasks: [{
+				id: "63C10CF0EF19F2C8"
+				type: "item"
+				item: "thermal:machine_smelter"
+			}]
+			rewards: [{
+				id: "579CC37AC45E0F27"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 4084485630345500261L
+			}]
+		}
+		{
+			x: -0.5d
+			y: 0.0d
+			shape: "hexagon"
+			subtitle: "The Basic Frame for Machines"
+			description: ["The Machine Frame is needed to craft various machines in Thermal Series."]
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "5F385CBA98795C62"
+			tasks: [{
+				id: "3EC446E752907C94"
+				type: "item"
+				item: "thermal:machine_frame"
+			}]
+			rewards: [
+				{
+					id: "157563CE4EFA237B"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "676677234F8E6F37"
+					type: "item"
+					item: "thermal:tin_gear"
+				}
+			]
+		}
+		{
+			x: 7.5d
+			y: -1.0d
+			shape: "hexagon"
+			subtitle: "Generates Power by Burning Items!"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "3DA93308D19BA85F"
+			tasks: [{
+				id: "4BEE939AC38768ED"
+				type: "item"
+				item: "thermal:dynamo_stirling"
+			}]
+			rewards: [
+				{
+					id: "108A20AE0FED5D27"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "37C6557D14C3B84F"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 7.5d
+			y: 0.0d
+			shape: "hexagon"
+			subtitle: "Generates Power using Liquid Fuel!"
+			description: ["Note: This accepts Tree Oil, Creosote Oil, and Refined Fuel."]
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "7FE2EED58AB791E8"
+			tasks: [{
+				id: "6E5C2E9D729210C9"
+				type: "item"
+				item: "thermal:dynamo_compression"
+			}]
+			rewards: [
+				{
+					id: "7B21F4A9F2C52F51"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "55D2678D9291832E"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 8.5d
+			y: -1.0d
+			shape: "hexagon"
+			subtitle: "Generates Power using Lava!"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "2F71FCE4E576C977"
+			tasks: [{
+				id: "52A52D9AC73D57A6"
+				type: "item"
+				item: "thermal:dynamo_magmatic"
+			}]
+			rewards: [
+				{
+					id: "317ED7FF0734E5F1"
+					type: "item"
+					item: "minecraft:lava_bucket"
+				}
+				{
+					id: "79A13EA08A164B86"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "41E6EC8E3C06061C"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 8.5d
+			y: 1.0d
+			shape: "hexagon"
+			subtitle: "Generates Power using Gems!"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "72C1C2CE02DCBDFF"
+			tasks: [{
+				id: "7B973B2B2EED7921"
+				type: "item"
+				item: "thermal:dynamo_lapidary"
+			}]
+			rewards: [
+				{
+					id: "2D68111DA1CB4560"
+					type: "item"
+					item: "minecraft:lapis_lazuli"
+					count: 2
+					random_bonus: 2
+				}
+				{
+					id: "48E74944FEA0ECC1"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "7926D9E21CB2619E"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 7.5d
+			y: 1.0d
+			shape: "hexagon"
+			subtitle: "Generates Power using Enchanted Items!"
+			description: [""]
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "2EAE9EDE6EFA59F0"
+			tasks: [{
+				id: "0E3CDD1130A56248"
+				type: "item"
+				item: "thermal:dynamo_disenchantment"
+			}]
+			rewards: [
+				{
+					id: "7A632E03F9CD6324"
+					type: "item"
+					item: "minecraft:book"
+				}
+				{
+					id: "47096C6969AB1279"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "29522020DC292C43"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 8.5d
+			y: 0.0d
+			shape: "hexagon"
+			subtitle: "Generates Power using Food?"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "40ADAB71DB70EF32"
+			tasks: [{
+				id: "795A2D642A7B7D50"
+				type: "item"
+				item: "thermal:dynamo_gourmand"
+			}]
+			rewards: [
+				{
+					id: "557845C485F475BB"
+					type: "item"
+					item: "minecraft:cooked_beef"
+					count: 4
+				}
+				{
+					id: "7C366B7A8CE82E4B"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "2891293FF4320701"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 0.5d
+			y: 2.0d
+			shape: "hexagon"
+			subtitle: "Tier 1 Base Upgrade"
+			description: [
+				"This is a base upgrade for all machines and items."
+				""
+				"Note: While you can put several base upgrades into a machine, only the highest tier takes effect."
+			]
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "76084BE1BBCF941F"
+			tasks: [{
+				id: "3EE6189C5B2FDD2F"
+				type: "item"
+				item: "thermal:upgrade_augment_1"
+			}]
+			rewards: [
+				{
+					id: "7CD91CF01EAA7BCD"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "41F233A7DA531268"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 1.5d
+			y: 2.0d
+			shape: "hexagon"
+			subtitle: "Tier 2 Base Upgrade"
+			description: [
+				"This is a tier 2 upgrade for Thermal Series items and machines."
+				""
+				"Note: While you can put several base upgrades into a machine, only the highest tier takes effect."
+			]
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "246CD1925FD6761C"
+			tasks: [{
+				id: "6AD321AC8D6BFDAD"
+				type: "item"
+				item: "thermal:upgrade_augment_2"
+			}]
+			rewards: [
+				{
+					id: "723FE016CAA6566D"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "5BBF7DC26AAA8E5C"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 2.5d
+			y: 2.0d
+			shape: "hexagon"
+			subtitle: "Tier 3 Base Upgrade"
+			description: ["Note: While you can put several base upgrades into a machine, only the highest tier takes effect."]
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "034FC4BCCCD7D154"
+			tasks: [{
+				id: "5237B4381DA7BE1B"
+				type: "item"
+				item: "thermal:upgrade_augment_3"
+			}]
+			rewards: [
+				{
+					id: "6724D7DE6CC92091"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "7FDD47DE35B3118B"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: -5.0d
+			y: 2.5d
+			shape: "diamond"
+			description: ["Creates an infinite water source when placed between two water source blocks."]
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "213FFA67A680E534"
+			tasks: [{
+				id: "07C7BA8E13F85930"
+				type: "item"
+				item: "thermal:device_water_gen"
+			}]
+			rewards: [
+				{
+					id: "46E591F83A20EB99"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "2EFF31E232EEE6C9"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: -4.5d
+			y: 3.0d
+			shape: "diamond"
+			subtitle: "Charges Items"
+			description: ["This machine charges the items placed inside."]
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "5FDEAA78891874FD"
+			tasks: [{
+				id: "2BB7C4355B61F638"
+				type: "item"
+				item: "thermal:charge_bench"
+			}]
+			rewards: [
+				{
+					id: "16C939074FA98D0B"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "597BC09E9D2C10DC"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: -4.5d
+			y: 2.0d
+			shape: "diamond"
+			subtitle: "A Cobblestone Generator"
+			description: [
+				"This machine can produce several types of stone."
+				""
+				"Place 1 lava source block on one side, and 1 water source block on the other, and it will generate cobblestone. Check the recipes to see the other kinds of stone you can create!"
+			]
+			hide_dependency_lines: false
+			dependencies: ["2C50B0E024C3D92E"]
+			optional: true
+			id: "4EA8BA9753D0DD81"
+			tasks: [{
+				id: "2720B59BB163F73B"
+				type: "item"
+				item: "thermal:device_rock_gen"
+			}]
+			rewards: [
+				{
+					id: "600EF049B3363CCC"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "40CEEE4ADD1FA55B"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: -2.0d
+			y: -2.0d
+			shape: "diamond"
+			description: [
+				"Can convert certain blocks into liquids."
+				""
+				"This is useful for generating lava from Cobblestone, Netherrack, etc."
+			]
+			dependencies: ["5F385CBA98795C62"]
+			id: "0897F7A3203E45AF"
+			tasks: [{
+				id: "3D2DFF6062AED26E"
+				type: "item"
+				item: "thermal:machine_crucible"
+			}]
+			rewards: [
+				{
+					id: "4C62A0183D243C27"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "039D39732BBFAFFB"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: -1.0d
+			y: -2.0d
+			shape: "diamond"
+			description: [
+				"This machine works like a Botany Pot, Garden Cloche, etc."
+				""
+				"When given water and a seed, it will grow the seed inside of the machine and auto-output the products into the machine."
+			]
+			dependencies: ["5F385CBA98795C62"]
+			id: "648B483B128A32F5"
+			tasks: [{
+				id: "61287BF539F0C5FC"
+				type: "item"
+				item: "thermal:machine_insolator"
+			}]
+			rewards: [
+				{
+					id: "265FD226E965D7B3"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "227035926BB39B13"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: -1.5d
+			y: -2.5d
+			shape: "diamond"
+			hide_dependency_lines: true
+			dependencies: ["5F385CBA98795C62"]
+			id: "66321E1F01C36567"
+			tasks: [{
+				id: "7A3BCB9C631D8FAD"
+				type: "item"
+				item: "thermal:machine_sawmill"
+			}]
+			rewards: [
+				{
+					id: "374BE54F4405BC0B"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "67F7D9F5A2A94DB0"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: -4.0d
+			y: 2.5d
+			shape: "diamond"
+			subtitle: "Vacuums up items"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "1B04B7EA5220D275"
+			tasks: [{
+				id: "3819DBE6E95E998E"
+				type: "item"
+				item: "thermal:device_collector"
+			}]
+			rewards: [
+				{
+					id: "7F764F32D74976B4"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "097275F0B8627600"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: -4.5d
+			y: -3.0d
+			shape: "diamond"
+			description: ["Spreads Potion Effects to an area."]
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "66858700C3DDCB9E"
+			tasks: [{
+				id: "590869F3AE44A956"
+				type: "item"
+				item: "thermal:device_potion_diffuser"
+			}]
+			rewards: [
+				{
+					id: "479CC02BC1343DBE"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "47F4FA57FE1B3D31"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: -4.5d
+			y: -2.0d
+			shape: "diamond"
+			description: ["Can be used to charge items, augment machines, or fill up items with liquid."]
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "74F524F4F0231A78"
+			tasks: [{
+				id: "5835951863555C2E"
+				type: "item"
+				item: "thermal:tinker_bench"
+			}]
+			rewards: [
+				{
+					id: "4E1086FC2DA044FC"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "2E52AE90CF44C0E3"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			title: "Storing Power"
+			x: -1.25d
+			y: 1.9499999999999997d
+			shape: "gear"
+			description: ["Pro Tip: You can enchant these with &9Capacity&r to increase the storage!"]
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			size: 1.5d
+			id: "037E566ACC83FE07"
+			tasks: [{
+				id: "64186CC4330A70D8"
+				type: "item"
+				item: {
+					id: "thermal:energy_cell"
+					Count: 1b
+					tag: {
+						BlockEntityTag: {
+							EnergyMax: 1000000
+							EnergySend: 1000
+							Energy: 0
+							EnergyRecv: 1000
+						}
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "54DBA686738A0538"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "65153D6D043E2D48"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			title: "Storing Fluids"
+			x: 5.25d
+			y: 1.9499999999999997d
+			shape: "gear"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			size: 1.5d
+			id: "4389E906A2A74867"
+			tasks: [{
+				id: "694DB377E094D28E"
+				type: "item"
+				item: {
+					id: "thermal:fluid_cell"
+					Count: 1b
+					tag: {
+						BlockEntityTag: {
+							TankInv: [{
+								FluidName: "minecraft:empty"
+								Capacity: 32000
+								Tank: 0b
+								Amount: 0
+							}]
+						}
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "4AE007FFAF1003F8"
+					type: "item"
+					item: "minecraft:bucket"
+				}
+				{
+					id: "43B8F1F2FBA0D4EA"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "09F8387B75BF87D2"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 1.0d
+			y: 5.0d
+			shape: "diamond"
+			subtitle: "Allows Storage of XP"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "483C1F4D099369A2"
+			tasks: [{
+				id: "66656B02B957573F"
+				type: "item"
+				item: "thermal:xp_storage_augment"
+			}]
+			rewards: [{
+				id: "1E92C5CEFFE3E4B3"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 4084485630345500261L
+			}]
+		}
+		{
+			title: "Expanded RF Coil"
+			x: 1.5d
+			y: 3.1999999999999993d
+			shape: "diamond"
+			subtitle: "Increases RF Capacity and Transfer Rate"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "0837E35C9C6881B4"
+			tasks: [{
+				id: "2F608F433D9A3363"
+				type: "item"
+				title: "Expanded RF Coil"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "thermal:rf_coil_augment"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_augment_1"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_augment_2"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_augment_3"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_augment_4"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_augment_5"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "3990D47351D43E1C"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "01159A5ECFD5CEE3"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 2.5d
+			y: 3.1999999999999993d
+			shape: "diamond"
+			subtitle: "Increases RF Capacity, and slightly increases the RF Transfer"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "3320ADFD7DC4CA00"
+			tasks: [{
+				id: "7B5C9FA866C0588A"
+				type: "item"
+				title: "Stabilized RF Coil"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "thermal:rf_coil_storage_augment"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_storage_augment_1"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_storage_augment_2"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_storage_augment_3"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_storage_augment_4"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_storage_augment_5"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "204DB02FD7E9A4F6"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "4E5306A22F3CF335"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 3.5d
+			y: 3.1999999999999993d
+			shape: "diamond"
+			subtitle: "Increases RF Transfer, and slightly increases the Capacity"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "79366EC1EE27ED4B"
+			tasks: [{
+				id: "775A7E11D20688CD"
+				type: "item"
+				title: "High-Flux RF Coil"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "thermal:rf_coil_xfer_augment"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_xfer_augment_1"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_xfer_augment_2"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_xfer_augment_3"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_xfer_augment_4"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:rf_coil_xfer_augment_5"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "591FD4F323E3FF7C"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "4E3CCEFC8C513A96"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 2.0d
+			y: 5.0d
+			shape: "diamond"
+			subtitle: "Increases Tank Storage"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "6DF4B859ACBCD408"
+			tasks: [{
+				id: "5DFD1C0334466FF2"
+				type: "item"
+				title: "Expanded Tank Construction"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "thermal:fluid_tank_augment"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:fluid_tank_augment_1"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:fluid_tank_augment_2"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:fluid_tank_augment_3"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:fluid_tank_augment_4"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:fluid_tank_augment_5"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:fluid_tank_augment_6"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [{
+				id: "1D4FCF5F1807C976"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 4084485630345500261L
+			}]
+		}
+		{
+			x: 1.5d
+			y: 5.5d
+			shape: "diamond"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "6D35E56FC874C841"
+			tasks: [{
+				id: "1726C6AB09496E0C"
+				type: "item"
+				item: "thermal:item_filter_augment"
+			}]
+			rewards: [{
+				id: "6F92134E16107738"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 4084485630345500261L
+			}]
+		}
+		{
+			x: 0.5d
+			y: 3.1999999999999993d
+			shape: "diamond"
+			subtitle: "Increases Processing Speed, but Reduces Efficiency"
+			description: [""]
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "74DD4F8A13EAD3ED"
+			tasks: [{
+				id: "46E665F97A2BECB6"
+				type: "item"
+				title: "Flux Linkage Amplifier"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "thermal:machine_speed_augment"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:machine_speed_augment_1"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:machine_speed_augment_2"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:machine_speed_augment_3"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:machine_speed_augment_4"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "10EE19CDB35235F4"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "0C6D5A95AEB654E7"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 1.0d
+			y: 3.6999999999999993d
+			shape: "diamond"
+			subtitle: "Increases Efficiency at the cost of Speed"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "61E2FC5D363A5CA4"
+			tasks: [{
+				id: "1E0593F1AA073CFD"
+				type: "item"
+				title: "Flux Efficiency"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "thermal:machine_efficiency_augment"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:machine_efficiency_augment_1"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:machine_efficiency_augment_2"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:machine_efficiency_augment_3"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:machine_efficiency_augment_4"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "5534C32BABF19B6D"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "4F9A9048D6B1E122"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 2.0d
+			y: 3.6999999999999993d
+			shape: "diamond"
+			subtitle: "Increases Secondary Output"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "58C6BAC128155B4E"
+			tasks: [{
+				id: "497485048E0AD20D"
+				type: "item"
+				title: "Auxiliary Process Sieve"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "thermal:machine_output_augment"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:machine_output_augment_1"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:machine_output_augment_2"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:machine_output_augment_3"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "1672462285E4696D"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "14B2F6450484E4A2"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 3.0d
+			y: 3.6999999999999993d
+			shape: "diamond"
+			subtitle: "Reduces Catalyst Usage"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "7D49A41E4D63A596"
+			tasks: [{
+				id: "6C996D5E63879519"
+				type: "item"
+				title: "Catalytic Reclamation Chamber"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "thermal:machine_catalyst_augment"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:machine_catalyst_augment_1"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:machine_catalyst_augment_2"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:machine_catalyst_augment_3"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "0410D3AC01336E89"
+					type: "item"
+					item: "minecraft:redstone"
+					count: 4
+				}
+				{
+					id: "40E9A3AF6C1A87BC"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "30529159C71287AD"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 2.5d
+			y: 5.5d
+			shape: "diamond"
+			subtitle: "Voids By-products"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "234CD79746FCAA18"
+			tasks: [{
+				id: "784D4494897AF202"
+				type: "item"
+				item: "thermal:machine_null_augment"
+			}]
+			rewards: [{
+				id: "67A2BAD4D9983E26"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 4084485630345500261L
+			}]
+		}
+		{
+			x: 8.0d
+			y: 2.0d
+			shape: "hexagon"
+			subtitle: "Increases Generation Rate at Cost of Efficiency"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "7C83735C2D746162"
+			tasks: [{
+				id: "3861678346D376C1"
+				type: "item"
+				title: "Auxiliary Reaction Chamber"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "thermal:dynamo_output_augment"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:dynamo_output_augment_1"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:dynamo_output_augment_2"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:dynamo_output_augment_3"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:dynamo_output_augment_4"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "4B8F25D9433225BF"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "62C2FF95B4AFD290"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 8.0d
+			y: -2.0d
+			shape: "hexagon"
+			subtitle: "Increases Fuel Efficiency of Dynamos"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "467CDD14AE21A850"
+			tasks: [{
+				id: "3D6A9C7EE22C2ADF"
+				type: "item"
+				title: "Multi-Cycle Injectors"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "thermal:dynamo_fuel_augment"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:dynamo_fuel_augment_1"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:dynamo_fuel_augment_2"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:dynamo_fuel_augment_3"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:dynamo_fuel_augment_4"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [
+				{
+					id: "6D0FE4CFD7575A75"
+					type: "xp"
+					xp: 10
+				}
+				{
+					id: "632467CB1FB36C7C"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 3.0d
+			y: 5.0d
+			shape: "diamond"
+			subtitle: "Increases AoE Effect"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "00C24A7DFEAEE956"
+			tasks: [{
+				id: "705AE21001A4E9C7"
+				type: "item"
+				title: "Radial Enchancement"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "thermal:area_radius_augment"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:area_radius_augment_1"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:area_radius_augment_2"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:area_radius_augment_3"
+								Count: 1b
+							}
+							{
+								id: "thermal_extra:area_radius_augment_4"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [{
+				id: "0162FC16A134829D"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 4084485630345500261L
+			}]
+		}
+		{
+			x: -5.0d
+			y: -2.5d
+			shape: "diamond"
+			subtitle: "Amplifies Potion Effect"
+			dependencies: ["66858700C3DDCB9E"]
+			id: "22A1C68078EFB38B"
+			tasks: [{
+				id: "08ED05EBDFF0B4D9"
+				type: "item"
+				item: "thermal:potion_amplifier_augment"
+			}]
+			rewards: [
+				{
+					id: "16143BA782E3D869"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "138DAAFCD3B6FA02"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: -4.0d
+			y: -2.5d
+			shape: "diamond"
+			subtitle: "Increases Duration of Potion Effect"
+			dependencies: ["66858700C3DDCB9E"]
+			id: "1714E1048F01E1AA"
+			tasks: [{
+				id: "501A3B2548F6DB3E"
+				type: "item"
+				item: "thermal:potion_duration_augment"
+			}]
+			rewards: [
+				{
+					id: "065A80C12CFDB394"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "088924775D906D4F"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 0.0d
+			y: -2.0d
+			shape: "diamond"
+			subtitle: "Separates Items into their Crafting Components"
+			description: ["This machine is mostly for extracting dyes from flowers, or ore blends back into their components."]
+			dependencies: ["5F385CBA98795C62"]
+			id: "3475E12711B6BB98"
+			tasks: [{
+				id: "2183800CED355EEB"
+				type: "item"
+				item: "thermal:machine_centrifuge"
+			}]
+			rewards: [{
+				id: "1F383E05B6EC4EBA"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 4084485630345500261L
+			}]
+		}
+		{
+			x: 0.5d
+			y: -2.5d
+			shape: "diamond"
+			description: [
+				"Creates \"Presses\" using Casts."
+				""
+				"Think plates, gears, etc."
+			]
+			hide_dependency_lines: true
+			dependencies: ["5F385CBA98795C62"]
+			id: "5963FBEB78A79668"
+			tasks: [{
+				id: "0C6725EA57E7D9EE"
+				type: "item"
+				item: "thermal:machine_press"
+			}]
+			rewards: [
+				{
+					id: "650B53A376632EC3"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "33791EEB04481324"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 1.0d
+			y: -2.0d
+			shape: "diamond"
+			description: [
+				"Converts items from a liquid to a solid, some requiring casts."
+				""
+				"There is also a bee spawn egg recipe it can create."
+			]
+			dependencies: ["5F385CBA98795C62"]
+			id: "469443A3BA0C3BEE"
+			tasks: [{
+				id: "66AF5C07727A5B39"
+				type: "item"
+				item: "thermal:machine_chiller"
+			}]
+			rewards: [{
+				id: "122EF97CC1EE4796"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 4084485630345500261L
+			}]
+		}
+		{
+			x: 0.0d
+			y: -3.0d
+			shape: "diamond"
+			description: ["Can convert liquids into items or other useful liquids."]
+			hide_dependency_lines: true
+			dependencies: ["5F385CBA98795C62"]
+			id: "627D6FDC3D8C42F6"
+			tasks: [{
+				id: "3B188F7D7009093C"
+				type: "item"
+				item: "thermal:machine_refinery"
+			}]
+			rewards: [
+				{
+					id: "7D725FF8CB44785C"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "1542C8A8F5D61DF4"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: -2.0d
+			y: -3.0d
+			shape: "diamond"
+			description: [
+				"Works like a Coke Oven, but simplified."
+				""
+				"Insert \"fuel\" like Coal and it'll produce Coal Coke and a by-product."
+			]
+			hide_dependency_lines: true
+			dependencies: ["5F385CBA98795C62"]
+			id: "5ECC93FB8F676E3F"
+			tasks: [{
+				id: "76A0C32FB86A089D"
+				type: "item"
+				item: "thermal:machine_pyrolyzer"
+			}]
+			rewards: [
+				{
+					id: "5AA3B772E203E40C"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "14D5E1E129094120"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: -1.0d
+			y: -3.0d
+			shape: "diamond"
+			description: ["Combines Liquids with Items"]
+			hide_dependency_lines: true
+			dependencies: ["5F385CBA98795C62"]
+			id: "469663FE3DA932EF"
+			tasks: [{
+				id: "05867D444D20EABE"
+				type: "item"
+				item: "thermal:machine_bottler"
+			}]
+			rewards: [
+				{
+					id: "05CAA4581B7D1435"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "60A961BFD670E1CB"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: -0.5d
+			y: -2.5d
+			shape: "diamond"
+			description: ["Can Create \"Liquid\" Potions that can be bottled into Potions."]
+			hide_dependency_lines: true
+			dependencies: ["5F385CBA98795C62"]
+			id: "1BCE8D02CDD13838"
+			tasks: [{
+				id: "70EF981620DADB32"
+				type: "item"
+				item: "thermal:machine_brewer"
+			}]
+			rewards: [
+				{
+					id: "46E350F851A4013C"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "7098EB6DA90F8839"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 1.0d
+			y: -3.0d
+			shape: "diamond"
+			subtitle: "An Auto-Crafter!"
+			hide_dependency_lines: true
+			dependencies: ["5F385CBA98795C62"]
+			id: "7AAEFA2A349D3F82"
+			tasks: [{
+				id: "72EC640A6F6C69C1"
+				type: "item"
+				item: "thermal:machine_crafter"
+			}]
+			rewards: [
+				{
+					id: "4FE6677655F3B4DD"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "154618A70AD2759D"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 3.5d
+			y: -2.5d
+			shape: "octagon"
+			subtitle: "An Early-Game Mining Gadget"
+			description: ["It's more like a pickaxe that uses RF/FE."]
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "5257468DC6C11851"
+			tasks: [{
+				id: "38EE8C011F7E3FEC"
+				type: "item"
+				item: {
+					id: "thermal:flux_drill"
+					Count: 1b
+					tag: { }
+				}
+			}]
+			rewards: [
+				{
+					id: "7029BD256EF4EEBD"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "275B06A629DE52A9"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 4.5d
+			y: -2.5d
+			shape: "octagon"
+			subtitle: "RF-Powered Handsaw!"
+			hide_dependency_lines: true
+			dependencies: ["2C50B0E024C3D92E"]
+			id: "6BF6B00BC21CA547"
+			tasks: [{
+				id: "504ABB4FCF4AA14E"
+				type: "item"
+				item: {
+					id: "thermal:flux_saw"
+					Count: 1b
+					tag: { }
+				}
+			}]
+			rewards: [
+				{
+					id: "539EF1C8332A468C"
+					type: "xp"
+					xp: 100
+				}
+				{
+					id: "719A845ADA2DE52B"
+					type: "random"
+					exclude_from_claim_all: true
+					table_id: 4084485630345500261L
+				}
+			]
+		}
+		{
+			x: 3.5d
+			y: 2.0d
+			shape: "hexagon"
+			subtitle: "Tier 4 Base Upgrade"
+			hide_dependency_lines: true
+			dependencies: ["034FC4BCCCD7D154"]
+			id: "76BCB8C0448EFE50"
+			tasks: [{
+				id: "41B789CFB591439D"
+				type: "item"
+				item: "thermal_extra:upgrade_augment"
+			}]
+			rewards: [{
+				id: "1CAE757FEEC6C318"
+				type: "random"
+				exclude_from_claim_all: true
+				table_id: 4084485630345500261L
+			}]
+		}
+	]
+	quest_links: [ ]
+}

--- a/config/ftbquests/quests/chapters/tips_and_tricks.snbt
+++ b/config/ftbquests/quests/chapters/tips_and_tricks.snbt
@@ -1,9 +1,9 @@
 {
 	id: "1BE666F01EFFC00D"
 	group: ""
-	order_index: 2
+	order_index: 4
 	filename: "tips_and_tricks"
-	title: "Tips \\& Tricks"
+	title: "&bTips \\& Tricks"
 	default_quest_shape: "diamond"
 	default_hide_dependency_lines: false
 	images: [{
@@ -20,6 +20,7 @@
 	}]
 	quests: [
 		{
+			title: "Infinite Water"
 			x: 3.0d
 			y: 6.0d
 			subtitle: "Can be used as Reactor Coolant"
@@ -391,6 +392,8 @@
 				"If you haven't played MC since 1.16, it's important to know that Ore Generation has changed as well as max build level."
 				""
 				"Make sure to check out the \"World Gen\" tab in the ore's recipe to see the Y level the ore generates!"
+				""
+				"Note: This currently only works in Single-player."
 			]
 			id: "7732A4AE58D1315E"
 			tasks: [{
@@ -415,14 +418,33 @@
 			x: -2.0d
 			y: 5.0d
 			subtitle: "A Simple Magnet!"
+			description: [
+				"This is a simple magnet!"
+				""
+				"Pro tip: You can set a keybind to toggle this on and off!"
+			]
 			id: "3FC002E5A6C08DCC"
 			tasks: [{
-				id: "4112D6272EC400DE"
+				id: "27CB2988681DB62C"
 				type: "item"
+				title: "Simple Magnets"
 				item: {
-					id: "simplemagnets:basicmagnet"
+					id: "itemfilters:or"
 					Count: 1b
-					tag: { }
+					tag: {
+						items: [
+							{
+								id: "simplemagnets:basicmagnet"
+								Count: 1b
+								tag: { }
+							}
+							{
+								id: "simplemagnets:advancedmagnet"
+								Count: 1b
+								tag: { }
+							}
+						]
+					}
 				}
 			}]
 			rewards: [
@@ -497,10 +519,10 @@
 					xp: 1000
 				}
 				{
-					id: "252305AEF12B1572"
+					id: "04C2C8FE21BE2CB7"
 					type: "random"
 					exclude_from_claim_all: true
-					table_id: 7025454341029952768L
+					table_id: 5564196992594175882L
 				}
 			]
 		}
@@ -832,6 +854,7 @@
 			}]
 		}
 		{
+			title: "Preventing Mob Spawns"
 			x: 0.5d
 			y: 7.5d
 			description: [
@@ -860,6 +883,7 @@
 			]
 		}
 		{
+			title: "Storing Experience"
 			x: 1.5d
 			y: 7.5d
 			description: [

--- a/config/ftbquests/quests/chapters/twilight_forest.snbt
+++ b/config/ftbquests/quests/chapters/twilight_forest.snbt
@@ -197,6 +197,11 @@
 					advancement: "twilightforest:twilight_dinner"
 					criterion: ""
 				}
+				{
+					id: "74B7BA7AA89EEECD"
+					type: "item"
+					item: "twilightforest:torchberries"
+				}
 			]
 			rewards: [
 				{
@@ -1393,7 +1398,7 @@
 			x: -2.0d
 			y: 0.10000000000000003d
 			shape: "diamond"
-			description: ["This item will prevent you from losing the items in your held items and armor when you die."]
+			description: ["This item will prevent you from losing the items in your main and off hand, as well as your armor when you die."]
 			dependencies: ["4B95D48D7525FFAD"]
 			id: "610F9E9D0B5131C7"
 			tasks: [{
@@ -1879,7 +1884,7 @@
 			description: [
 				"This item is like a torch launcher. It launches &6Moonworms&r at the targeted block, which light up the block similar to a torch."
 				""
-				"You can find this in Hollow Hill treasure chests."
+				"You can find this in some Hollow Hill and Lich Tower treasure chests."
 			]
 			hide_dependency_lines: true
 			dependencies: ["4193303999597249"]

--- a/config/ftbquests/quests/reward_tables/EssenceBag.snbt
+++ b/config/ftbquests/quests/reward_tables/EssenceBag.snbt
@@ -1,0 +1,81 @@
+{
+	id: "49E8BD91A6A936C5"
+	order_index: 24
+	title: "&5Essence Bag"
+	icon: "mysticalagriculture:inferium_essence"
+	loot_size: 1
+	use_title: true
+	rewards: [
+		{ item: "mysticalagriculture:inferium_essence", count: 8, random_bonus: 8, weight: 250.0f }
+		{ item: "mysticalagriculture:prudentium_essence", count: 2, random_bonus: 2, weight: 150.0f }
+		{ item: "mysticalagriculture:tertium_essence", count: 2, random_bonus: 2, weight: 50.0f }
+		{ item: "mysticalagriculture:imperium_essence", count: 2, random_bonus: 2, weight: 25.0f }
+		{ item: "mysticalagriculture:supremium_essence", random_bonus: 1, weight: 5.0f }
+		{ item: "mysticalagriculture:fertilized_essence", count: 5, random_bonus: 10, weight: 150.0f }
+		{
+			item: {
+				id: "minecraft:enchanted_book"
+				Count: 1b
+				tag: {
+					StoredEnchantments: [{
+						lvl: 1s
+						id: "mysticalagriculture:mystical_enlightenment"
+					}]
+				}
+			}
+			weight: 100.0f
+		}
+		{
+			item: {
+				id: "minecraft:enchanted_book"
+				Count: 1b
+				tag: {
+					StoredEnchantments: [{
+						lvl: 2s
+						id: "mysticalagriculture:mystical_enlightenment"
+					}]
+				}
+			}
+			weight: 50.0f
+		}
+		{
+			item: {
+				id: "minecraft:enchanted_book"
+				Count: 1b
+				tag: {
+					StoredEnchantments: [{
+						lvl: 3s
+						id: "mysticalagriculture:mystical_enlightenment"
+					}]
+				}
+			}
+			weight: 25.0f
+		}
+		{
+			item: {
+				id: "minecraft:enchanted_book"
+				Count: 1b
+				tag: {
+					StoredEnchantments: [{
+						lvl: 4s
+						id: "mysticalagriculture:mystical_enlightenment"
+					}]
+				}
+			}
+			weight: 25.0f
+		}
+		{
+			item: {
+				id: "minecraft:enchanted_book"
+				Count: 1b
+				tag: {
+					StoredEnchantments: [{
+						lvl: 5s
+						id: "mysticalagriculture:mystical_enlightenment"
+					}]
+				}
+			}
+			weight: 5.0f
+		}
+	]
+}

--- a/config/ftbquests/quests/reward_tables/ThermalLootBag.snbt
+++ b/config/ftbquests/quests/reward_tables/ThermalLootBag.snbt
@@ -1,0 +1,50 @@
+{
+	id: "38AF020A4EEE5665"
+	order_index: 25
+	title: "&9Thermal Loot Bag"
+	icon: "thermal:upgrade_augment_3"
+	loot_size: 1
+	use_title: true
+	rewards: [
+		{ item: "thermal:machine_frame", weight: 100.0f }
+		{
+			item: {
+				id: "thermal:energy_cell"
+				Count: 1b
+				tag: {
+					BlockEntityTag: {
+						EnergyMax: 1000000
+						EnergySend: 1000
+						Energy: 0
+						EnergyRecv: 1000
+					}
+				}
+			}
+			weight: 25.0f
+		}
+		{ item: "thermal:energy_duct", count: 4, random_bonus: 4, weight: 250.0f }
+		{ item: "thermal:fluid_duct", count: 4, random_bonus: 4, weight: 150.0f }
+		{ item: "thermal:redstone_servo", count: 2, random_bonus: 2, weight: 100.0f }
+		{ item: "thermal:rf_coil", random_bonus: 3, weight: 250.0f }
+		{ item: "thermal:upgrade_augment_1", weight: 50.0f }
+		{ item: "thermal:upgrade_augment_2", weight: 25.0f }
+		{ item: "thermal:upgrade_augment_3", weight: 5.0f }
+		{ item: "thermal:rf_coil_augment", weight: 50.0f }
+		{ item: "thermal:machine_speed_augment", weight: 100.0f }
+		{ item: "thermal:machine_output_augment", weight: 50.0f }
+		{ item: "thermal:servo_attachment", weight: 50.0f }
+		{ item: "thermal:turbo_servo_attachment", weight: 25.0f }
+		{ item: "thermal:explosive_grenade", weight: 25.0f }
+		{ item: "thermal:earth_grenade", weight: 10.0f }
+		{ item: "minecraft:gold_ingot", random_bonus: 7, weight: 100.0f }
+		{ item: "alltheores:lead_ingot", random_bonus: 7, weight: 100.0f }
+		{ item: "alltheores:tin_ingot", random_bonus: 7, weight: 100.0f }
+		{ item: "alltheores:invar_ingot", random_bonus: 3, weight: 50.0f }
+		{ item: "alltheores:electrum_ingot", random_bonus: 3, weight: 50.0f }
+		{ item: "alltheores:bronze_ingot", random_bonus: 3, weight: 50.0f }
+		{ item: "alltheores:enderium_ingot", random_bonus: 3, weight: 5.0f }
+		{ item: "alltheores:lumium_ingot", random_bonus: 3, weight: 50.0f }
+		{ item: "alltheores:signalum_ingot", random_bonus: 3, weight: 50.0f }
+		{ item: "alltheores:constantan_ingot", random_bonus: 3, weight: 50.0f }
+	]
+}

--- a/config/ftbquests/quests/reward_tables/Tier1_Seed Bag.snbt
+++ b/config/ftbquests/quests/reward_tables/Tier1_Seed Bag.snbt
@@ -1,0 +1,54 @@
+{
+	id: "5AF0FD7302DEC2B1"
+	order_index: 18
+	title: "&aTier 1 Seed Bag"
+	icon: "mysticalagriculture:inferium_gemstone"
+	loot_size: 1
+	use_title: true
+	rewards: [
+		{ item: "mysticalagriculture:inferium_essence", count: 2, random_bonus: 2, weight: 10.0f }
+		{ item: "mysticalagriculture:inferium_seeds", random_bonus: 1, weight: 5.0f }
+		{ item: "mysticalagriculture:inferium_block", weight: 5.0f }
+		{ item: "mysticalagriculture:inferium_furnace", weight: 3.0f }
+		{ item: "mysticalagriculture:inferium_growth_accelerator", weight: 2.0f }
+		{ item: "mysticalagriculture:inferium_gemstone", weight: 3.0f }
+		{ item: "mysticalagriculture:inferium_ingot", random_bonus: 2, weight: 5.0f }
+		{ item: "mysticalagradditions:inferium_coal", random_bonus: 3, weight: 5.0f }
+		{ item: "mysticalagradditions:inferium_apple", random_bonus: 2, weight: 5.0f }
+		{ item: "mysticalagriculture:inferium_farmland", random_bonus: 2, weight: 7.0f }
+		{ item: "mysticalagriculture:prosperity_seed_base", random_bonus: 2, weight: 5.0f }
+		{ item: "mysticalagriculture:prosperity_gemstone", random_bonus: 1, weight: 3.0f }
+		{ item: "mysticalagriculture:prosperity_ingot", random_bonus: 3, weight: 10.0f }
+		{ item: "mysticalagriculture:prosperity_shard", count: 4, random_bonus: 8, weight: 10.0f }
+		{ item: "mysticalagriculture:prosperity_block", weight: 5.0f }
+		{ item: "mysticalagriculture:fertilized_essence", random_bonus: 2 }
+		{
+			item: {
+				id: "minecraft:enchanted_book"
+				Count: 1b
+				tag: {
+					StoredEnchantments: [{
+						lvl: 1s
+						id: "mysticalagriculture:mystical_enlightenment"
+					}]
+				}
+			}
+		}
+		{ item: "mysticalagriculture:unattuned_augment", weight: 5.0f }
+		{ item: "mysticalagriculture:soulium_ingot", weight: 3.0f }
+		{ item: "mysticalagriculture:soulium_ore", random_bonus: 1, weight: 5.0f }
+		{ item: "mysticalagriculture:soulstone_cobble", count: 2, random_bonus: 3, weight: 5.0f }
+		{ item: "mysticalagriculture:soul_glass", weight: 3.0f }
+		{ item: "mysticalagriculture:soul_jar" }
+		{
+			item: {
+				id: "mysticalagriculture:infusion_crystal"
+				Count: 1b
+				tag: {
+					Damage: 0
+				}
+			}
+			weight: 2.0f
+		}
+	]
+}

--- a/config/ftbquests/quests/reward_tables/Tier2_Seed Bag.snbt
+++ b/config/ftbquests/quests/reward_tables/Tier2_Seed Bag.snbt
@@ -1,0 +1,43 @@
+{
+	id: "21B1896C13F84C09"
+	order_index: 19
+	title: "&2Tier 2 Seed Bag"
+	icon: "mysticalagriculture:prudentium_gemstone"
+	loot_size: 1
+	use_title: true
+	rewards: [
+		{ item: "mysticalagriculture:nature_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:dye_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:nether_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:coal_seeds" }
+		{ item: "mysticalagriculture:honey_seeds" }
+		{ item: "mysticalagriculture:amethyst_seeds", weight: 2.0f }
+		{ item: "mysticalagriculture:aluminum_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:apatite_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:mystical_flower_seeds", weight: 2.0f }
+		{ item: "mysticalagradditions:prudentium_apple", weight: 7.0f }
+		{ item: "mysticalagradditions:prudentium_coal_block", weight: 3.0f }
+		{ item: "mysticalagriculture:mining_aoe_i_augment" }
+		{ item: "mysticalagriculture:speed_i_augment" }
+		{ item: "mysticalagriculture:health_boost_ii_augment" }
+		{ item: "mysticalagriculture:water_breathing_augment" }
+		{ item: "mysticalagriculture:night_vision_augment" }
+		{ item: "mysticalagriculture:menril_seeds", weight: 2.0f }
+		{ item: "mysticalagriculture:limestone_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:prudentium_block", weight: 3.0f }
+		{ item: "mysticalagriculture:prudentium_farmland", weight: 7.0f }
+		{ item: "mysticalagriculture:prudentium_growth_accelerator", weight: 5.0f }
+		{ item: "mysticalagriculture:prudentium_furnace", weight: 5.0f }
+		{ item: "mysticalagriculture:prudentium_essence", count: 4, random_bonus: 4, weight: 10.0f }
+		{ item: "mysticalagriculture:prudentium_ingot", random_bonus: 2, weight: 7.0f }
+		{ item: "mysticalagriculture:prudentium_gemstone", weight: 5.0f }
+		{ item: "mysticalagriculture:pig_seeds" }
+		{ item: "mysticalagriculture:chicken_seeds" }
+		{ item: "mysticalagriculture:cow_seeds" }
+		{ item: "mysticalagriculture:sheep_seeds" }
+		{ item: "mysticalagriculture:squid_seeds" }
+		{ item: "mysticalagriculture:fish_seeds" }
+		{ item: "mysticalagriculture:slime_seeds" }
+		{ item: "mysticalagriculture:turtle_seeds" }
+	]
+}

--- a/config/ftbquests/quests/reward_tables/Tier3_Seed Bag.snbt
+++ b/config/ftbquests/quests/reward_tables/Tier3_Seed Bag.snbt
@@ -1,0 +1,44 @@
+{
+	id: "6B7F78B9150AFFEE"
+	order_index: 20
+	title: "&cTier 3 Seed Bag"
+	icon: "mysticalagriculture:tertium_gemstone"
+	loot_size: 1
+	use_title: true
+	rewards: [
+		{ item: "mysticalagriculture:tertium_farmland", weight: 5.0f }
+		{ item: "mysticalagriculture:iron_seeds", weight: 2.0f }
+		{ item: "mysticalagriculture:copper_seeds", weight: 5.0f }
+		{ item: "mysticalagriculture:nether_quartz_seeds", weight: 2.0f }
+		{ item: "mysticalagriculture:glowstone_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:redstone_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:obsidian_seeds" }
+		{ item: "mysticalagriculture:prismarine_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:zombie_seeds", weight: 2.0f }
+		{ item: "mysticalagriculture:silver_seeds", weight: 2.0f }
+		{ item: "mysticalagriculture:brass_seeds" }
+		{ item: "mysticalagriculture:zinc_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:bronze_seeds" }
+		{ item: "mysticalagriculture:tin_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:rabbit_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:spider_seeds", weight: 2.0f }
+		{ item: "mysticalagriculture:creeper_seeds" }
+		{ item: "mysticalagriculture:skeleton_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:lead_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:blizz_seeds" }
+		{ item: "mysticalagriculture:blitz_seeds" }
+		{ item: "mysticalagriculture:basalz_seeds" }
+		{ item: "mysticalagriculture:certus_quartz_seeds", weight: 2.0f }
+		{ item: "mysticalagriculture:quartz_enriched_iron_seeds" }
+		{ item: "mysticalagriculture:no_fall_damage_augment" }
+		{ item: "mysticalagriculture:mining_aoe_ii_augment" }
+		{ item: "mysticalagriculture:tertium_essence", random_bonus: 2, weight: 10.0f }
+		{ item: "mysticalagriculture:tertium_furnace" }
+		{ item: "mysticalagriculture:tertium_ingot", random_bonus: 1, weight: 7.0f }
+		{ item: "mysticalagriculture:tertium_gemstone", weight: 5.0f }
+		{ item: "mysticalagriculture:tertium_block" }
+		{ item: "mysticalagradditions:tertium_apple", random_bonus: 2, weight: 7.0f }
+		{ item: "mysticalagradditions:tertium_coal", random_bonus: 3, weight: 5.0f }
+		{ item: "mysticalagradditions:tertium_coal_block", weight: 3.0f }
+	]
+}

--- a/config/ftbquests/quests/reward_tables/Tier4_SeedBag.snbt
+++ b/config/ftbquests/quests/reward_tables/Tier4_SeedBag.snbt
@@ -1,0 +1,42 @@
+{
+	id: "61F8686E9D8EFEB7"
+	order_index: 21
+	title: "&9Tier 4 Seed Bag"
+	icon: "mysticalagriculture:imperium_gemstone"
+	loot_size: 1
+	use_title: true
+	rewards: [
+		{ item: "mysticalagriculture:imperium_farmland", weight: 7.0f }
+		{ item: "mysticalagriculture:gold_seeds", weight: 2.0f }
+		{ item: "mysticalagriculture:lapis_lazuli_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:end_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:experience_seeds" }
+		{ item: "mysticalagriculture:blaze_seeds", weight: 2.0f }
+		{ item: "mysticalagriculture:ghast_seeds" }
+		{ item: "mysticalagriculture:enderman_seeds", weight: 2.0f }
+		{ item: "mysticalagriculture:steel_seeds", weight: 2.0f }
+		{ item: "mysticalagriculture:nickel_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:constantan_seeds" }
+		{ item: "mysticalagriculture:electrum_seeds" }
+		{ item: "mysticalagriculture:invar_seeds" }
+		{ item: "mysticalagriculture:uranium_seeds", weight: 2.0f }
+		{ item: "mysticalagriculture:ruby_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:sapphire_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:signalum_seeds" }
+		{ item: "mysticalagriculture:lumium_seeds" }
+		{ item: "mysticalagriculture:osmium_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:fluorite_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:refined_glowstone_seeds", weight: 2.0f }
+		{ item: "mysticalagriculture:refined_obsidian_seeds" }
+		{ item: "mysticalagriculture:fluix_seeds", weight: 2.0f }
+		{ item: "mysticalagradditions:imperium_coal", random_bonus: 3, weight: 7.0f }
+		{ item: "mysticalagradditions:imperium_coal_block", weight: 5.0f }
+		{ item: "mysticalagradditions:imperium_apple", random_bonus: 2, weight: 10.0f }
+		{ item: "mysticalagriculture:imperium_essence", random_bonus: 3, weight: 7.0f }
+		{ item: "mysticalagriculture:imperium_block" }
+		{ item: "mysticalagriculture:imperium_growth_accelerator", weight: 5.0f }
+		{ item: "mysticalagriculture:imperium_furnace", weight: 5.0f }
+		{ item: "mysticalagriculture:imperium_ingot", random_bonus: 1, weight: 5.0f }
+		{ item: "mysticalagriculture:imperium_gemstone", weight: 5.0f }
+	]
+}

--- a/config/ftbquests/quests/reward_tables/Tier5_SeedBag.snbt
+++ b/config/ftbquests/quests/reward_tables/Tier5_SeedBag.snbt
@@ -1,0 +1,30 @@
+{
+	id: "3256FDEE1B753EE1"
+	order_index: 22
+	title: "&4Tier 5 Seed Bag"
+	icon: "minecraft:chest"
+	loot_size: 1
+	rewards: [
+		{ item: "mysticalagriculture:diamond_seeds" }
+		{ item: "mysticalagriculture:supremium_farmland", weight: 10.0f }
+		{ item: "mysticalagriculture:emerald_seeds" }
+		{ item: "mysticalagriculture:netherite_seeds" }
+		{ item: "mysticalagriculture:wither_skeleton_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:platinum_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:iridium_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:enderium_seeds" }
+		{ item: "mysticalagriculture:uraninite_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:supremium_furnace", weight: 3.0f }
+		{ item: "mysticalagriculture:supremium_growth_accelerator", weight: 5.0f }
+		{ item: "mysticalagriculture:supremium_block" }
+		{ item: "mysticalagradditions:supremium_apple", weight: 10.0f }
+		{ item: "mysticalagradditions:supremium_coal", weight: 7.0f }
+		{ item: "mysticalagradditions:supremium_coal_block", weight: 5.0f }
+		{ item: "mysticalagriculture:strength_iii_augment", weight: 3.0f }
+		{ item: "mysticalagriculture:health_boost_v_augment", weight: 3.0f }
+		{ item: "mysticalagriculture:flight_augment" }
+		{ item: "mysticalagriculture:supremium_essence", random_bonus: 1, weight: 10.0f }
+		{ item: "mysticalagriculture:supremium_ingot", random_bonus: 2, weight: 5.0f }
+		{ item: "mysticalagriculture:supremium_gemstone", random_bonus: 1, weight: 5.0f }
+	]
+}

--- a/config/ftbquests/quests/reward_tables/Tier6Seed Bag.snbt
+++ b/config/ftbquests/quests/reward_tables/Tier6Seed Bag.snbt
@@ -1,0 +1,31 @@
+{
+	id: "32D89E2679C55D75"
+	order_index: 23
+	title: "&dTier 6 Seed Bag"
+	icon: "mysticalagradditions:insanium_gemstone"
+	loot_size: 1
+	use_title: true
+	rewards: [
+		{ item: "mysticalagriculture:dragon_egg_seeds" }
+		{ item: "mysticalagriculture:nether_star_seeds" }
+		{ item: "mysticalagradditions:insanium_farmland", weight: 7.0f }
+		{ item: "mysticalagradditions:insanium_coal_block", weight: 5.0f }
+		{ item: "mysticalagradditions:insanium_essence", random_bonus: 1, weight: 5.0f }
+		{ item: "mysticalagradditions:insanium_ingot", weight: 7.0f }
+		{ item: "mysticalagradditions:insanium_gemstone", weight: 5.0f }
+		{ item: "mysticalagradditions:insanium_coal", random_bonus: 2, weight: 5.0f }
+		{ item: "mysticalagradditions:insanium_apple", random_bonus: 2, weight: 7.0f }
+		{ item: "mysticalagradditions:supremium_coal_block", weight: 5.0f }
+		{ item: "mysticalagriculture:supremium_furnace", weight: 3.0f }
+		{ item: "mysticalagriculture:supremium_farmland", weight: 10.0f }
+		{ item: "mysticalagriculture:supremium_gemstone", weight: 7.0f }
+		{ item: "mysticalagriculture:supremium_ingot", random_bonus: 2, weight: 10.0f }
+		{ item: "mysticalagriculture:supremium_essence", random_bonus: 3, weight: 10.0f }
+		{ item: "mysticalagriculture:flight_augment", weight: 3.0f }
+		{ item: "mysticalagriculture:terrasteel_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:enderium_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:netherite_seeds", weight: 3.0f }
+		{ item: "mysticalagriculture:emerald_seeds", weight: 5.0f }
+		{ item: "mysticalagriculture:diamond_seeds", weight: 7.0f }
+	]
+}

--- a/config/ftbquests/quests/reward_tables/ae2_basic_reward_table.snbt
+++ b/config/ftbquests/quests/reward_tables/ae2_basic_reward_table.snbt
@@ -3,15 +3,16 @@
 	order_index: 5
 	title: "AE2 Medium Reward Bag"
 	loot_size: 1
+	use_title: true
 	rewards: [
-		{ item: "ae2:certus_quartz_crystal", count: 2, random_bonus: 2, weight: 4 }
-		{ item: "ae2:certus_quartz_dust", count: 4, random_bonus: 4, weight: 5 }
-		{ item: "ae2:silicon", count: 4, random_bonus: 4, weight: 3 }
-		{ item: "ae2:printed_silicon", count: 2, random_bonus: 1, weight: 2 }
-		{ item: "ae2:charged_certus_quartz_crystal", count: 2, weight: 3 }
-		{ item: "ae2:fluix_crystal", count: 2, random_bonus: 2, weight: 2 }
-		{ item: "ae2:fluix_dust", random_bonus: 2, weight: 2 }
-		{ item: "ae2:logic_processor", count: 2, random_bonus: 1, weight: 2 }
+		{ item: "ae2:certus_quartz_crystal", count: 2, random_bonus: 2, weight: 4.0f }
+		{ item: "ae2:certus_quartz_dust", count: 4, random_bonus: 4, weight: 5.0f }
+		{ item: "ae2:silicon", count: 4, random_bonus: 4, weight: 3.0f }
+		{ item: "ae2:printed_silicon", count: 2, random_bonus: 1, weight: 2.0f }
+		{ item: "ae2:charged_certus_quartz_crystal", count: 2, weight: 3.0f }
+		{ item: "ae2:fluix_crystal", count: 2, random_bonus: 2, weight: 2.0f }
+		{ item: "ae2:fluix_dust", random_bonus: 2, weight: 2.0f }
+		{ item: "ae2:logic_processor", count: 2, random_bonus: 1, weight: 2.0f }
 		{ item: "ae2:calculation_processor", random_bonus: 1 }
 		{ item: "ae2:engineering_processor" }
 		{ item: "ae2:formation_core" }

--- a/config/ftbquests/quests/reward_tables/ae2_basic_rewards.snbt
+++ b/config/ftbquests/quests/reward_tables/ae2_basic_rewards.snbt
@@ -3,11 +3,12 @@
 	order_index: 6
 	title: "AE2 Basic Rewards"
 	loot_size: 1
+	use_title: true
 	rewards: [
-		{ item: "ae2:certus_quartz_crystal", count: 2, random_bonus: 2, weight: 10 }
-		{ item: "ae2:certus_quartz_dust", count: 4, random_bonus: 4, weight: 10 }
+		{ item: "ae2:certus_quartz_crystal", count: 2, random_bonus: 2, weight: 10.0f }
+		{ item: "ae2:certus_quartz_dust", count: 4, random_bonus: 4, weight: 10.0f }
 		{ item: "ae2:fluix_crystal", random_bonus: 1 }
 		{ item: "ae2:fluix_dust", random_bonus: 1 }
-		{ item: "ae2:charged_certus_quartz_crystal", count: 2, random_bonus: 2, weight: 5 }
+		{ item: "ae2:charged_certus_quartz_crystal", count: 2, random_bonus: 2, weight: 5.0f }
 	]
 }

--- a/config/ftbquests/quests/reward_tables/ars_nouveau_rewards.snbt
+++ b/config/ftbquests/quests/reward_tables/ars_nouveau_rewards.snbt
@@ -3,18 +3,19 @@
 	order_index: 7
 	title: "Ars Nouveau Rewards"
 	loot_size: 1
+	use_title: true
 	rewards: [
-		{ item: "ars_nouveau:source_gem", count: 2, random_bonus: 2, weight: 50 }
-		{ item: "ars_nouveau:abjuration_essence", count: 2, random_bonus: 2, weight: 5 }
-		{ item: "ars_nouveau:conjuration_essence", count: 2, random_bonus: 2, weight: 5 }
-		{ item: "ars_nouveau:air_essence", count: 2, random_bonus: 2, weight: 5 }
-		{ item: "ars_nouveau:fire_essence", count: 2, random_bonus: 2, weight: 5 }
-		{ item: "ars_nouveau:earth_essence", count: 2, random_bonus: 2, weight: 5 }
-		{ item: "ars_nouveau:water_essence", count: 2, random_bonus: 2, weight: 5 }
-		{ item: "ars_nouveau:wilden_spike", count: 2, random_bonus: 2, weight: 25 }
-		{ item: "ars_nouveau:wilden_wing", count: 2, random_bonus: 2, weight: 25 }
-		{ item: "ars_nouveau:wilden_horn", count: 2, random_bonus: 2, weight: 25 }
-		{ item: "ars_nouveau:source_berry", count: 4, random_bonus: 4, weight: 25 }
-		{ item: "ars_nouveau:starbuncle_shards", count: 2, random_bonus: 2, weight: 10 }
+		{ item: "ars_nouveau:source_gem", count: 2, random_bonus: 2, weight: 50.0f }
+		{ item: "ars_nouveau:abjuration_essence", count: 2, random_bonus: 2, weight: 5.0f }
+		{ item: "ars_nouveau:conjuration_essence", count: 2, random_bonus: 2, weight: 5.0f }
+		{ item: "ars_nouveau:air_essence", count: 2, random_bonus: 2, weight: 5.0f }
+		{ item: "ars_nouveau:fire_essence", count: 2, random_bonus: 2, weight: 5.0f }
+		{ item: "ars_nouveau:earth_essence", count: 2, random_bonus: 2, weight: 5.0f }
+		{ item: "ars_nouveau:water_essence", count: 2, random_bonus: 2, weight: 5.0f }
+		{ item: "ars_nouveau:wilden_spike", count: 2, random_bonus: 2, weight: 25.0f }
+		{ item: "ars_nouveau:wilden_wing", count: 2, random_bonus: 2, weight: 25.0f }
+		{ item: "ars_nouveau:wilden_horn", count: 2, random_bonus: 2, weight: 25.0f }
+		{ item: "ars_nouveau:source_berry", count: 4, random_bonus: 4, weight: 25.0f }
+		{ item: "ars_nouveau:starbuncle_shards", count: 2, random_bonus: 2, weight: 10.0f }
 	]
 }

--- a/config/ftbquests/quests/reward_tables/common.snbt
+++ b/config/ftbquests/quests/reward_tables/common.snbt
@@ -10,14 +10,15 @@
 		}
 	}
 	loot_size: 1
+	use_title: true
 	rewards: [
-		{ item: "botanypots:terracotta_hopper_botany_pot", weight: 5 }
+		{ item: "botanypots:terracotta_hopper_botany_pot", weight: 5.0f }
 		{ item: "mysticalagriculture:imperium_essence" }
 		{ item: "reliquary:fertile_lily_pad" }
-		{ item: "minecraft:fox_spawn_egg", weight: 5 }
-		{ item: "functionalstorage:copper_upgrade", weight: 5 }
-		{ item: "functionalstorage:oak_1", random_bonus: 2, weight: 7 }
-		{ item: "functionalstorage:void_upgrade", weight: 3 }
+		{ item: "minecraft:fox_spawn_egg", weight: 5.0f }
+		{ item: "functionalstorage:copper_upgrade", weight: 5.0f }
+		{ item: "functionalstorage:oak_1", random_bonus: 2, weight: 7.0f }
+		{ item: "functionalstorage:void_upgrade", weight: 3.0f }
 		{ item: "functionalstorage:storage_controller" }
 		{
 			item: {
@@ -27,9 +28,9 @@
 					Storage: { }
 				}
 			}
-			weight: 5
+			weight: 5.0f
 		}
-		{ item: "waystones:waystone", weight: 3 }
+		{ item: "waystones:waystone", weight: 3.0f }
 		{
 			item: {
 				id: "utilitix:mob_yoinker"
@@ -38,55 +39,44 @@
 					filled: 0b
 				}
 			}
-			weight: 3
+			weight: 3.0f
 		}
-		{ item: "waystones:warp_plate", count: 2, weight: 3 }
-		{ item: "dankstorage:dank_1", weight: 5 }
+		{ item: "waystones:warp_plate", count: 2, weight: 3.0f }
+		{ item: "dankstorage:dank_1", weight: 5.0f }
 		{
 			item: {
 				id: "simplemagnets:advancedmagnet"
 				Count: 1b
 				tag: { }
 			}
-			weight: 2
+			weight: 2.0f
 		}
-		{ item: "cookingforblockheads:sink", weight: 5 }
-		{ item: "ironfurnaces:augment_speed", weight: 5 }
-		{ item: "ironfurnaces:augment_factory", weight: 5 }
-		{ item: "ironfurnaces:item_spooky", weight: 3 }
+		{ item: "cookingforblockheads:sink", weight: 5.0f }
+		{ item: "ironfurnaces:augment_speed", weight: 5.0f }
+		{ item: "ironfurnaces:augment_factory", weight: 5.0f }
+		{ item: "ironfurnaces:item_spooky", weight: 3.0f }
 		{ item: "ars_nouveau:glyph_summon_wolves" }
 		{ item: "ars_nouveau:glyph_light" }
-		{ item: "pipez:universal_pipe", count: 8, random_bonus: 8, weight: 5 }
-		{ item: "minecraft:diamond", random_bonus: 2, weight: 3 }
+		{ item: "pipez:universal_pipe", count: 8, random_bonus: 8, weight: 5.0f }
+		{ item: "minecraft:diamond", random_bonus: 2, weight: 3.0f }
 		{
 			item: {
 				id: "simplemagnets:basicmagnet"
 				Count: 1b
 				tag: { }
 			}
-			weight: 4
+			weight: 4.0f
 		}
-		{ item: "torchmaster:megatorch", weight: 5 }
-		{ item: "productivebees:upgrade_base", weight: 2 }
-		{ item: "sophisticatedstorage:basic_to_iron_tier_upgrade", weight: 5 }
-		{ item: "sophisticatedstorage:upgrade_base", weight: 5 }
-		{ item: "sophisticatedbackpacks:upgrade_base", weight: 5 }
-		{
-			item: {
-				id: "sophisticatedbackpacks:backpack"
-				Count: 1b
-				tag: {
-					inventorySlots: 27
-					upgradeSlots: 1
-				}
-			}
-			weight: 5
-		}
-		{ item: "pipez:basic_upgrade", weight: 7 }
-		{ item: "mekanism:basic_tier_installer", weight: 3 }
-		{ item: "mekanism:upgrade_speed", weight: 3 }
-		{ item: "mekanism:upgrade_energy", weight: 3 }
-		{ item: "productivebees:sturdy_bee_cage", weight: 5 }
+		{ item: "torchmaster:megatorch", weight: 5.0f }
+		{ item: "productivebees:upgrade_base", weight: 2.0f }
+		{ item: "sophisticatedstorage:basic_to_iron_tier_upgrade", weight: 5.0f }
+		{ item: "sophisticatedstorage:upgrade_base", weight: 5.0f }
+		{ item: "sophisticatedbackpacks:upgrade_base", weight: 5.0f }
+		{ item: "pipez:basic_upgrade", weight: 7.0f }
+		{ item: "mekanism:basic_tier_installer", weight: 3.0f }
+		{ item: "mekanism:upgrade_speed", weight: 3.0f }
+		{ item: "mekanism:upgrade_energy", weight: 3.0f }
+		{ item: "productivebees:sturdy_bee_cage", weight: 5.0f }
 		{
 			item: {
 				id: "minecraft:potion"
@@ -95,7 +85,7 @@
 					Potion: "potionsmaster:iron_sight"
 				}
 			}
-			weight: 3
+			weight: 3.0f
 		}
 		{
 			item: {
@@ -107,13 +97,13 @@
 			}
 		}
 		{ item: "modularrouters:modular_router" }
-		{ item: "minecraft:iron_ingot", count: 4, random_bonus: 4, weight: 7 }
-		{ item: "minecraft:gold_ingot", count: 2, random_bonus: 2, weight: 5 }
-		{ item: "minecraft:redstone", count: 8, random_bonus: 8, weight: 5 }
-		{ item: "mysticalagriculture:tertium_essence", weight: 2 }
-		{ item: "mysticalagriculture:prudentium_essence", count: 2, random_bonus: 1, weight: 3 }
-		{ item: "mekanismgenerators:wind_generator", weight: 5 }
-		{ item: "minecraft:torch", count: 4, random_bonus: 8, weight: 10 }
+		{ item: "minecraft:iron_ingot", count: 4, random_bonus: 4, weight: 7.0f }
+		{ item: "minecraft:gold_ingot", count: 2, random_bonus: 2, weight: 5.0f }
+		{ item: "minecraft:redstone", count: 8, random_bonus: 8, weight: 5.0f }
+		{ item: "mysticalagriculture:tertium_essence", weight: 2.0f }
+		{ item: "mysticalagriculture:prudentium_essence", count: 2, random_bonus: 1, weight: 3.0f }
+		{ item: "mekanismgenerators:wind_generator", weight: 5.0f }
+		{ item: "minecraft:torch", count: 4, random_bonus: 8, weight: 10.0f }
 		{
 			item: {
 				id: "minecraft:enchanted_book"
@@ -222,8 +212,8 @@
 				}
 			}
 		}
-		{ item: "minecraft:slime_ball", count: 6, random_bonus: 6, weight: 7 }
-		{ item: "minecraft:name_tag", weight: 3 }
+		{ item: "minecraft:slime_ball", count: 6, random_bonus: 6, weight: 7.0f }
+		{ item: "minecraft:name_tag", weight: 3.0f }
 		{
 			item: {
 				id: "alltheores:copper_ore_hammer"
@@ -232,9 +222,9 @@
 					Damage: 0
 				}
 			}
-			weight: 5
+			weight: 5.0f
 		}
-		{ item: "minecraft:saddle", weight: 3 }
+		{ item: "minecraft:saddle", weight: 3.0f }
 		{
 			item: {
 				id: "constructionwand:iron_wand"
@@ -244,14 +234,14 @@
 					Damage: 0
 				}
 			}
-			weight: 5
+			weight: 5.0f
 		}
-		{ item: "minecraft:cat_spawn_egg", weight: 3 }
-		{ item: "minecraft:wolf_spawn_egg", weight: 5 }
-		{ item: "minecraft:parrot_spawn_egg", weight: 3 }
-		{ item: "minecraft:melon_seeds", count: 3, random_bonus: 3, weight: 10 }
-		{ item: "minecraft:lapis_lazuli", count: 4, random_bonus: 4, weight: 7 }
-		{ item: "mysticalagriculture:inferium_seeds", weight: 3 }
+		{ item: "minecraft:cat_spawn_egg", weight: 3.0f }
+		{ item: "minecraft:wolf_spawn_egg", weight: 5.0f }
+		{ item: "minecraft:parrot_spawn_egg", weight: 3.0f }
+		{ item: "minecraft:melon_seeds", count: 3, random_bonus: 3, weight: 10.0f }
+		{ item: "minecraft:lapis_lazuli", count: 4, random_bonus: 4, weight: 7.0f }
+		{ item: "mysticalagriculture:inferium_seeds", weight: 3.0f }
 		{
 			item: {
 				id: "mysticalagriculture:inferium_sword"
@@ -297,21 +287,21 @@
 				}
 			}
 		}
-		{ item: "mysticalagriculture:inferium_essence", count: 8, random_bonus: 8, weight: 10 }
-		{ item: "minecraft:cooked_beef", count: 2, random_bonus: 2, weight: 10 }
-		{ item: "minecraft:cooked_porkchop", count: 2, random_bonus: 2, weight: 10 }
-		{ item: "minecraft:cooked_chicken", count: 3, random_bonus: 3, weight: 10 }
-		{ item: "minecraft:oak_log", count: 8, random_bonus: 8, weight: 15 }
-		{ item: "minecraft:stone", count: 4, random_bonus: 8, weight: 10 }
-		{ item: "minecraft:quartz", count: 2, random_bonus: 2, weight: 3 }
-		{ item: "minecraft:feather", count: 4, random_bonus: 4, weight: 7 }
-		{ item: "minecraft:blaze_rod", random_bonus: 1, weight: 3 }
-		{ item: "minecraft:ender_pearl", count: 2, random_bonus: 1, weight: 3 }
-		{ item: "minecraft:bucket", weight: 7 }
-		{ item: "functionalstorage:oak_2", random_bonus: 2, weight: 5 }
-		{ item: "functionalstorage:oak_4", random_bonus: 2, weight: 5 }
-		{ item: "ironfurnaces:iron_furnace", weight: 10 }
-		{ item: "ironfurnaces:gold_furnace", weight: 3 }
+		{ item: "mysticalagriculture:inferium_essence", count: 8, random_bonus: 8, weight: 10.0f }
+		{ item: "minecraft:cooked_beef", count: 2, random_bonus: 2, weight: 10.0f }
+		{ item: "minecraft:cooked_porkchop", count: 2, random_bonus: 2, weight: 10.0f }
+		{ item: "minecraft:cooked_chicken", count: 3, random_bonus: 3, weight: 10.0f }
+		{ item: "minecraft:oak_log", count: 8, random_bonus: 8, weight: 15.0f }
+		{ item: "minecraft:stone", count: 4, random_bonus: 8, weight: 10.0f }
+		{ item: "minecraft:quartz", count: 2, random_bonus: 2, weight: 3.0f }
+		{ item: "minecraft:feather", count: 4, random_bonus: 4, weight: 7.0f }
+		{ item: "minecraft:blaze_rod", random_bonus: 1, weight: 3.0f }
+		{ item: "minecraft:ender_pearl", count: 2, random_bonus: 1, weight: 3.0f }
+		{ item: "minecraft:bucket", weight: 7.0f }
+		{ item: "functionalstorage:oak_2", random_bonus: 2, weight: 5.0f }
+		{ item: "functionalstorage:oak_4", random_bonus: 2, weight: 5.0f }
+		{ item: "ironfurnaces:iron_furnace", weight: 10.0f }
+		{ item: "ironfurnaces:gold_furnace", weight: 3.0f }
 		{
 			item: {
 				id: "alltheores:iron_ore_hammer"
@@ -320,13 +310,13 @@
 					Damage: 0
 				}
 			}
-			weight: 3
+			weight: 3.0f
 		}
-		{ item: "minecraft:honeycomb", random_bonus: 3, weight: 7 }
-		{ item: "minecraft:honey_bottle", random_bonus: 2, weight: 7 }
-		{ item: "productivebees:honey_treat", random_bonus: 2, weight: 5 }
-		{ item: "minecraft:beehive", weight: 7 }
-		{ item: "productivebees:advanced_oak_beehive", weight: 5 }
+		{ item: "minecraft:honeycomb", random_bonus: 3, weight: 7.0f }
+		{ item: "minecraft:honey_bottle", random_bonus: 2, weight: 7.0f }
+		{ item: "productivebees:honey_treat", random_bonus: 2, weight: 5.0f }
+		{ item: "minecraft:beehive", weight: 7.0f }
+		{ item: "productivebees:advanced_oak_beehive", weight: 5.0f }
 		{
 			item: {
 				id: "buildinggadgets:gadget_building"
@@ -347,31 +337,31 @@
 			command: "/sgear_random_gear @p silentgear:hammer 2"
 			player_command: false
 			type: "command"
-			weight: 5
+			weight: 5.0f
 		}
 		{
 			command: "/sgear_random_gear @p silentgear:hammer 3"
 			player_command: false
 			type: "command"
-			weight: 3
+			weight: 3.0f
 		}
 		{
 			command: "/sgear_random_gear @p silentgear:pickaxe 2"
 			player_command: false
 			type: "command"
-			weight: 7
+			weight: 7.0f
 		}
 		{
 			command: "/sgear_random_gear @p silentgear:pickaxe 3"
 			player_command: false
 			type: "command"
-			weight: 5
+			weight: 5.0f
 		}
 		{
 			command: "/sgear_random_gear @p silentgear:paxel 3"
 			player_command: false
 			type: "command"
-			weight: 3
+			weight: 3.0f
 		}
 		{ item: "powah:magmator_basic" }
 		{ item: "powah:furnator_basic" }

--- a/config/ftbquests/quests/reward_tables/epic.snbt
+++ b/config/ftbquests/quests/reward_tables/epic.snbt
@@ -4,32 +4,12 @@
 	title: "&dEpic Reward"
 	icon: "lootr:lootr_chest"
 	loot_size: 1
+	use_title: true
 	rewards: [
-		{
-			item: {
-				id: "ironjetpacks:jetpack"
-				Count: 1b
-				tag: {
-					Id: "ironjetpacks:diamond"
-					Throttle: 1.0d
-				}
-			}
-		}
-		{ item: "sophisticatedbackpacks:stack_upgrade_tier_3" }
+		{ item: "sophisticatedbackpacks:stack_upgrade_tier_3", weight: 3.0f }
 		{ item: "powah:thermo_generator_niotic" }
 		{ item: "powah:thermo_generator_spirited" }
 		{ item: "tempad:he_who_remains_tempad" }
-		{
-			item: {
-				id: "sophisticatedbackpacks:netherite_backpack"
-				Count: 1b
-				tag: {
-					inventorySlots: 120
-					upgradeSlots: 7
-				}
-			}
-		}
-		{ item: "rftoolsbuilder:builder" }
 		{
 			item: {
 				id: "mekanism:elite_energy_cube"
@@ -44,10 +24,9 @@
 				}
 			}
 		}
-		{ item: "functionalstorage:netherite_upgrade" }
+		{ item: "functionalstorage:netherite_upgrade", weight: 2.0f }
 		{ item: "quarryplus:quarry" }
-		{ item: "pipez:ultimate_upgrade" }
-		{ item: "dankstorage:dank_6" }
+		{ item: "pipez:ultimate_upgrade", random_bonus: 2, weight: 2.0f }
 		{ item: "mekanism:ultimate_tier_installer" }
 		{ item: "thermal:upgrade_augment_3" }
 		{ item: "ironfurnaces:netherite_furnace" }
@@ -138,6 +117,6 @@
 			}
 		}
 		{ item: "mekanism:quantum_entangloporter" }
-		{ item: "apotheosis:epic_material", count: 2, random_bonus: 4, weight: 3 }
+		{ item: "apotheosis:epic_material", count: 2, random_bonus: 4, weight: 3.0f }
 	]
 }

--- a/config/ftbquests/quests/reward_tables/legendary.snbt
+++ b/config/ftbquests/quests/reward_tables/legendary.snbt
@@ -4,143 +4,24 @@
 	title: "&6Legendary Reward"
 	icon: "lootr:trophy"
 	loot_size: 1
+	use_title: true
 	rewards: [
-		{
-			item: {
-				id: "minecraft:potion"
-				Count: 1b
-				tag: {
-					Potion: "potionsmaster:allthemodium_sight"
-				}
-			}
-		}
 		{ item: "apotheosis:library" }
-		{ item: "apotheosis:mythic_material" }
-		{ item: "apotheosis:superior_sigil_of_socketing" }
+		{ item: "apotheosis:mythic_material", random_bonus: 5, weight: 2.0f }
+		{ item: "apotheosis:superior_sigil_of_socketing", random_bonus: 2, weight: 2.0f }
 		{ item: "mekanism:atomic_disassembler" }
 		{ item: "mekanism:mekasuit_helmet" }
 		{ item: "mekanism:mekasuit_bodyarmor" }
 		{ item: "mekanism:mekasuit_pants" }
 		{ item: "mekanism:mekasuit_boots" }
-		{ item: "allthemodium:raw_allthemodium" }
-		{ item: "sophisticatedbackpacks:stack_upgrade_tier_4" }
+		{ item: "sophisticatedbackpacks:stack_upgrade_tier_4", weight: 3.0f }
 		{ item: "sophisticatedstorage:stack_upgrade_tier_4" }
-		{ item: "mysticalagriculture:supremium_essence" }
-		{ item: "powah:thermo_generator_spirited" }
-		{ item: "powah:solar_panel_spirited" }
+		{ item: "mysticalagriculture:supremium_essence", random_bonus: 2, weight: 2.0f }
+		{ item: "powah:thermo_generator_spirited", weight: 2.0f }
+		{ item: "powah:solar_panel_spirited", weight: 2.0f }
 		{ item: "powah:solar_panel_nitro" }
 		{ item: "powah:reactor_spirited", count: 36 }
-		{ item: "allthetweaks:nether_star_block" }
-		{
-			item: {
-				id: "apotheosis:gem"
-				Count: 1b
-				tag: {
-					variant: 4
-					purity: 0.71428573f
-					modifier: {
-						Operation: 0
-						attribute: "minecraft:generic.max_health"
-						UUID: [I;
-							-674418209
-							1676625129
-							-1495307635
-							617608105
-						]
-						Amount: 10.0d
-						Name: "GemBonus_apotheosis:max_health"
-					}
-				}
-			}
-		}
-		{
-			item: {
-				id: "apotheosis:gem"
-				Count: 1b
-				tag: {
-					variant: 4
-					purity: 1.0f
-					modifier: {
-						Operation: 0
-						attribute: "minecraft:generic.max_health"
-						UUID: [I;
-							-159938437
-							182471178
-							-1511767853
-							439964346
-						]
-						Amount: 14.0d
-						Name: "GemBonus_apotheosis:max_health"
-					}
-				}
-			}
-		}
-		{
-			item: {
-				id: "apotheosis:gem"
-				Count: 1b
-				tag: {
-					variant: 2
-					purity: 0.47058824f
-					modifier: {
-						Operation: 0
-						attribute: "minecraft:generic.luck"
-						UUID: [I;
-							-1326343963
-							176439867
-							-1699904368
-							-1615260257
-						]
-						Amount: 4.0d
-						Name: "GemBonus_apotheosis:luck"
-					}
-				}
-			}
-		}
-		{
-			item: {
-				id: "apotheosis:gem"
-				Count: 1b
-				tag: {
-					variant: 2
-					purity: 0.7058824f
-					modifier: {
-						Operation: 0
-						attribute: "minecraft:generic.luck"
-						UUID: [I;
-							-1876790363
-							-362593241
-							-1755550234
-							-1215113379
-						]
-						Amount: 6.0d
-						Name: "GemBonus_apotheosis:luck"
-					}
-				}
-			}
-		}
-		{
-			item: {
-				id: "apotheosis:gem"
-				Count: 1b
-				tag: {
-					variant: 2
-					purity: 0.9411765f
-					modifier: {
-						Operation: 0
-						attribute: "minecraft:generic.luck"
-						UUID: [I;
-							-336425622
-							1175601606
-							-1482833734
-							986668186
-						]
-						Amount: 8.0d
-						Name: "GemBonus_apotheosis:luck"
-					}
-				}
-			}
-		}
+		{ item: "allthetweaks:nether_star_block", random_bonus: 1 }
 		{
 			item: {
 				id: "quark:ancient_tome"
@@ -177,6 +58,6 @@
 				}
 			}
 		}
-		{ item: "compactmachines:machine_maximum" }
+		{ item: "thermal_extra:upgrade_augment" }
 	]
 }

--- a/config/ftbquests/quests/reward_tables/mekanism.snbt
+++ b/config/ftbquests/quests/reward_tables/mekanism.snbt
@@ -3,11 +3,12 @@
 	order_index: 4
 	title: "Mekanism: Basic Rewards"
 	loot_size: 1
+	use_title: true
 	rewards: [
-		{ item: "mekanism:alloy_infused", count: 2, random_bonus: 2, weight: 4 }
-		{ item: "mekanism:basic_control_circuit", count: 2, random_bonus: 2, weight: 4 }
-		{ item: "mekanism:alloy_reinforced", random_bonus: 1, weight: 2 }
-		{ item: "mekanism:advanced_control_circuit", random_bonus: 1, weight: 2 }
-		{ item: "alltheores:osmium_ingot", count: 4, random_bonus: 2, weight: 4 }
+		{ item: "mekanism:alloy_infused", count: 2, random_bonus: 2, weight: 4.0f }
+		{ item: "mekanism:basic_control_circuit", count: 2, random_bonus: 2, weight: 4.0f }
+		{ item: "mekanism:alloy_reinforced", random_bonus: 1, weight: 2.0f }
+		{ item: "mekanism:advanced_control_circuit", random_bonus: 1, weight: 2.0f }
+		{ item: "alltheores:osmium_ingot", count: 4, random_bonus: 2, weight: 4.0f }
 	]
 }

--- a/config/ftbquests/quests/reward_tables/mythic.snbt
+++ b/config/ftbquests/quests/reward_tables/mythic.snbt
@@ -4,61 +4,17 @@
 	title: "&5Mythic Reward"
 	icon: "minecraft:nether_star"
 	loot_size: 1
+	use_title: true
 	rewards: [
 		{ item: "mekanism:pellet_antimatter" }
-		{ item: "allthemodium:raw_vibranium", random_bonus: 3, weight: 3 }
-		{ item: "allthemodium:raw_unobtainium", random_bonus: 3, weight: 3 }
-		{ item: "allthemodium:unobtainium_allthemodium_alloy_ingot", random_bonus: 2, weight: 2 }
-		{ item: "allthemodium:unobtainium_vibranium_alloy_ingot", random_bonus: 2, weight: 2 }
-		{ item: "allthemodium:vibranium_allthemodium_alloy_ingot", random_bonus: 2 }
-		{ item: "allthemodium:piglich_heart", random_bonus: 3, weight: 3 }
-		{ item: "allthemodium:allthemodium_sword", weight: 2 }
-		{ item: "allthemodium:allthemodium_pickaxe", weight: 2 }
-		{ item: "allthemodium:allthemodium_axe", weight: 2 }
-		{ item: "allthemodium:allthemodium_shovel", weight: 2 }
-		{ item: "allthemodium:allthemodium_boots" }
-		{ item: "allthemodium:allthemodium_leggings" }
-		{ item: "allthemodium:allthemodium_chestplate" }
-		{ item: "allthemodium:allthemodium_helmet" }
-		{
-			item: {
-				id: "apotheosis:potion_charm"
-				Count: 1b
-				tag: {
-					Damage: 0
-					Potion: "potionsmaster:allthemodium_sight"
-				}
-			}
-		}
-		{
-			item: {
-				id: "apotheosis:potion_charm"
-				Count: 1b
-				tag: {
-					Damage: 0
-					Potion: "potionsmaster:vibranium_sight"
-				}
-			}
-			weight: 2
-		}
-		{
-			item: {
-				id: "apotheosis:potion_charm"
-				Count: 1b
-				tag: {
-					Damage: 0
-					Potion: "potionsmaster:unobtainium_sight"
-				}
-			}
-			weight: 2
-		}
+		{ item: "allthemodium:unobtainium_allthemodium_alloy_ingot", random_bonus: 2, weight: 3.0f }
+		{ item: "allthemodium:unobtainium_vibranium_alloy_ingot", random_bonus: 2, weight: 3.0f }
+		{ item: "allthemodium:vibranium_allthemodium_alloy_ingot", random_bonus: 2, weight: 3.0f }
+		{ item: "allthemodium:piglich_heart", random_bonus: 3, weight: 3.0f }
 		{ item: "botania:life_essence" }
-		{ item: "elementalcraft:purecrystal", random_bonus: 1, weight: 4 }
+		{ item: "elementalcraft:purecrystal", random_bonus: 3, weight: 4.0f }
 		{ item: "elementalcraft:fireite_ingot" }
-		{ item: "ars_nouveau:ritual_wilden_summon", weight: 2 }
-		{ item: "mysticalagriculture:master_infusion_crystal", weight: 2 }
-		{ item: "mysticalagradditions:insanium_essence" }
-		{ item: "thermal_extra:upgrade_augment", weight: 3 }
-		{ item: "mekanism:atomic_disassembler" }
+		{ item: "mysticalagriculture:master_infusion_crystal", weight: 2.0f }
+		{ item: "mysticalagradditions:insanium_essence", random_bonus: 2 }
 	]
 }

--- a/config/ftbquests/quests/reward_tables/random_tier_1_glyph.snbt
+++ b/config/ftbquests/quests/reward_tables/random_tier_1_glyph.snbt
@@ -3,6 +3,7 @@
 	order_index: 8
 	title: "Random Tier 1 Glyph"
 	loot_size: 1
+	use_title: true
 	rewards: [
 		{ item: "ars_nouveau:glyph_ignite" }
 		{ item: "ars_nouveau:glyph_underfoot" }

--- a/config/ftbquests/quests/reward_tables/rare.snbt
+++ b/config/ftbquests/quests/reward_tables/rare.snbt
@@ -10,9 +10,10 @@
 		}
 	}
 	loot_size: 1
+	use_title: true
 	rewards: [
 		{ item: "sophisticatedbackpacks:everlasting_upgrade" }
-		{ item: "sophisticatedbackpacks:stack_upgrade_tier_2", weight: 5 }
+		{ item: "sophisticatedbackpacks:stack_upgrade_tier_2", weight: 5.0f }
 		{
 			item: {
 				id: "sophisticatedstorage:diamond_chest"
@@ -21,24 +22,13 @@
 					woodType: "oak"
 				}
 			}
-			weight: 5
+			weight: 5.0f
 		}
-		{ item: "sophisticatedstorage:stack_upgrade_tier_2", weight: 7 }
+		{ item: "sophisticatedstorage:stack_upgrade_tier_2", weight: 7.0f }
 		{ item: "thermal:upgrade_augment_2" }
-		{
-			item: {
-				id: "sophisticatedbackpacks:diamond_backpack"
-				Count: 1b
-				tag: {
-					inventorySlots: 108
-					upgradeSlots: 5
-				}
-			}
-			weight: 2
-		}
-		{ item: "sophisticatedbackpacks:advanced_magnet_upgrade", weight: 3 }
+		{ item: "sophisticatedbackpacks:advanced_magnet_upgrade", weight: 3.0f }
 		{ item: "industrialforegoing:laser_drill" }
-		{ item: "functionalstorage:diamond_upgrade", weight: 3 }
+		{ item: "functionalstorage:diamond_upgrade", weight: 3.0f }
 		{
 			item: {
 				id: "minecraft:enchanted_book"
@@ -63,8 +53,8 @@
 				}
 			}
 		}
-		{ item: "pipez:advanced_upgrade", random_bonus: 2, weight: 5 }
-		{ item: "productivebees:upgrade_productivity", weight: 2 }
+		{ item: "pipez:advanced_upgrade", random_bonus: 2, weight: 5.0f }
+		{ item: "productivebees:upgrade_productivity", weight: 2.0f }
 		{
 			item: {
 				id: "quark:ancient_tome"
@@ -103,16 +93,6 @@
 		}
 		{
 			item: {
-				id: "ironjetpacks:jetpack"
-				Count: 1b
-				tag: {
-					Id: "ironjetpacks:gold"
-					Throttle: 1.0d
-				}
-			}
-		}
-		{
-			item: {
 				id: "mekanism:advanced_energy_cube"
 				Count: 1b
 				tag: {
@@ -124,36 +104,34 @@
 					}
 				}
 			}
-			weight: 2
+			weight: 2.0f
 		}
-		{ item: "mekanism:elite_tier_installer", weight: 3 }
-		{ item: "dankstorage:dank_4" }
-		{ item: "minecraft:dragon_egg", weight: 2 }
+		{ item: "mekanism:elite_tier_installer", weight: 3.0f }
+		{ item: "minecraft:dragon_egg", weight: 2.0f }
 		{ item: "minecraft:dragon_head" }
-		{ item: "dankstorage:dank_3", weight: 3 }
 		{ item: "artifacts:charm_of_sinking" }
-		{ item: "artifacts:vampiric_glove", weight: 2 }
+		{ item: "artifacts:vampiric_glove", weight: 2.0f }
 		{ item: "artifacts:umbrella" }
 		{ item: "artifacts:night_vision_goggles" }
-		{ item: "artifacts:golden_hook", weight: 2 }
+		{ item: "artifacts:golden_hook", weight: 2.0f }
 		{ item: "artifacts:crystal_heart" }
-		{ item: "ironfurnaces:diamond_furnace", weight: 3 }
+		{ item: "ironfurnaces:diamond_furnace", weight: 3.0f }
 		{ item: "ironfurnaces:emerald_furnace" }
-		{ item: "thermal:machine_speed_augment", weight: 5 }
-		{ item: "alltheores:enderium_ingot", random_bonus: 3, weight: 5 }
-		{ item: "alltheores:invar_ingot", random_bonus: 3, weight: 5 }
-		{ item: "minecraft:obsidian", count: 8, random_bonus: 8, weight: 10 }
-		{ item: "fluxnetworks:flux_dust", count: 2, random_bonus: 2, weight: 10 }
-		{ item: "fluxnetworks:flux_block", random_bonus: 1, weight: 3 }
-		{ item: "fluxnetworks:flux_point", weight: 5 }
-		{ item: "fluxnetworks:flux_plug", weight: 3 }
-		{ item: "fluxnetworks:basic_flux_storage", weight: 3 }
+		{ item: "thermal:machine_speed_augment", weight: 5.0f }
+		{ item: "alltheores:enderium_ingot", random_bonus: 3, weight: 5.0f }
+		{ item: "alltheores:invar_ingot", random_bonus: 3, weight: 5.0f }
+		{ item: "minecraft:obsidian", count: 8, random_bonus: 8, weight: 10.0f }
+		{ item: "fluxnetworks:flux_dust", count: 2, random_bonus: 2, weight: 10.0f }
+		{ item: "fluxnetworks:flux_block", random_bonus: 1, weight: 3.0f }
+		{ item: "fluxnetworks:flux_point", weight: 5.0f }
+		{ item: "fluxnetworks:flux_plug", weight: 3.0f }
+		{ item: "fluxnetworks:basic_flux_storage", weight: 3.0f }
 		{ item: "fluxnetworks:herculean_flux_storage" }
-		{ item: "mekanism:ultimate_universal_cable", count: 4, random_bonus: 4, weight: 5 }
+		{ item: "mekanism:ultimate_universal_cable", count: 4, random_bonus: 4, weight: 5.0f }
 		{ item: "pipez:ultimate_upgrade", random_bonus: 1 }
-		{ item: "mekanism:ingot_refined_obsidian", random_bonus: 3, weight: 5 }
-		{ item: "minecraft:diamond_block", random_bonus: 2, weight: 7 }
-		{ item: "minecraft:emerald_block", random_bonus: 1, weight: 5 }
+		{ item: "mekanism:ingot_refined_obsidian", random_bonus: 3, weight: 5.0f }
+		{ item: "minecraft:diamond_block", random_bonus: 2, weight: 7.0f }
+		{ item: "minecraft:emerald_block", random_bonus: 1, weight: 5.0f }
 		{
 			item: {
 				id: "apotheosis:potion_charm"
@@ -163,7 +141,7 @@
 					Potion: "potionsmaster:diamond_sight"
 				}
 			}
-			weight: 3
+			weight: 3.0f
 		}
 		{
 			item: {
@@ -174,7 +152,7 @@
 					Potion: "potionsmaster:emerald_sight"
 				}
 			}
-			weight: 2
+			weight: 2.0f
 		}
 		{
 			item: {
@@ -186,8 +164,8 @@
 				}
 			}
 		}
-		{ item: "minecraft:beacon", weight: 2 }
-		{ item: "minecraft:nether_star", random_bonus: 2, weight: 2 }
+		{ item: "minecraft:beacon", weight: 2.0f }
+		{ item: "minecraft:nether_star", random_bonus: 2, weight: 2.0f }
 		{
 			item: {
 				id: "ars_nouveau:enchanters_sword"
@@ -198,7 +176,7 @@
 			}
 		}
 		{ item: "ars_nouveau:basic_spell_turret" }
-		{ item: "ars_nouveau:apprentice_spell_book", weight: 2 }
+		{ item: "ars_nouveau:apprentice_spell_book", weight: 2.0f }
 		{
 			item: {
 				id: "ars_nouveau:wand"
@@ -219,18 +197,18 @@
 		{ item: "sophisticatedstorage:stack_upgrade_tier_3" }
 		{ item: "functionalstorage:netherite_upgrade" }
 		{ item: "tempad:tempad" }
-		{ item: "functionalstorage:gold_upgrade", random_bonus: 1, weight: 5 }
+		{ item: "functionalstorage:gold_upgrade", random_bonus: 1, weight: 5.0f }
 		{ item: "botania:endoflame" }
-		{ item: "minecraft:ghast_tear", random_bonus: 3, weight: 5 }
-		{ item: "ars_nouveau:source_gem_block", weight: 3 }
-		{ item: "minecraft:budding_amethyst", random_bonus: 2, weight: 5 }
+		{ item: "minecraft:ghast_tear", random_bonus: 3, weight: 5.0f }
+		{ item: "ars_nouveau:source_gem_block", weight: 3.0f }
+		{ item: "minecraft:budding_amethyst", random_bonus: 2, weight: 5.0f }
 		{
 			item: {
 				id: "mininggadgets:mininggadget_simple"
 				Count: 1b
 				tag: { }
 			}
-			weight: 2
+			weight: 2.0f
 		}
 		{
 			item: {
@@ -239,6 +217,6 @@
 				tag: { }
 			}
 		}
-		{ item: "apotheosis:rare_material", count: 2, random_bonus: 4, weight: 5 }
+		{ item: "apotheosis:rare_material", count: 2, random_bonus: 4, weight: 5.0f }
 	]
 }

--- a/config/ftbquests/quests/reward_tables/refined_storage_base_materials.snbt
+++ b/config/ftbquests/quests/reward_tables/refined_storage_base_materials.snbt
@@ -3,9 +3,10 @@
 	order_index: 2
 	title: "Refined Storage Base Materials"
 	loot_size: 1
+	use_title: true
 	rewards: [
 		{ item: "ae2:silicon", count: 5 }
-		{ item: "refinedstorage:quartz_enriched_iron", count: 5, weight: 2 }
+		{ item: "refinedstorage:quartz_enriched_iron", count: 5, weight: 2.0f }
 		{ item: "refinedstorage:machine_casing" }
 	]
 }

--- a/config/ftbquests/quests/reward_tables/refined_storage_parts.snbt
+++ b/config/ftbquests/quests/reward_tables/refined_storage_parts.snbt
@@ -3,9 +3,10 @@
 	order_index: 1
 	title: "Refined Storage Basic Parts"
 	loot_size: 1
+	use_title: true
 	rewards: [
-		{ item: "refinedstorage:basic_processor", count: 3, random_bonus: 3, weight: 40 }
-		{ item: "refinedstorage:improved_processor", count: 2, weight: 20 }
-		{ item: "refinedstorage:advanced_processor", weight: 5 }
+		{ item: "refinedstorage:basic_processor", count: 3, random_bonus: 3, weight: 40.0f }
+		{ item: "refinedstorage:improved_processor", count: 2, weight: 20.0f }
+		{ item: "refinedstorage:advanced_processor", weight: 5.0f }
 	]
 }

--- a/config/ftbquests/quests/reward_tables/rs_advanced_parts.snbt
+++ b/config/ftbquests/quests/reward_tables/rs_advanced_parts.snbt
@@ -3,8 +3,9 @@
 	order_index: 11
 	title: "RS Advanced Parts"
 	loot_size: 1
+	use_title: true
 	rewards: [
-		{ item: "extradisks:withering_processor", random_bonus: 2, weight: 10 }
-		{ item: "extrastorage:neural_processor", random_bonus: 2, weight: 50 }
+		{ item: "extradisks:withering_processor", random_bonus: 2, weight: 10.0f }
+		{ item: "extrastorage:neural_processor", random_bonus: 2, weight: 50.0f }
 	]
 }

--- a/config/ftbquests/quests/reward_tables/rs_random_storage_parts.snbt
+++ b/config/ftbquests/quests/reward_tables/rs_random_storage_parts.snbt
@@ -3,10 +3,11 @@
 	order_index: 10
 	title: "RS Random Storage Parts"
 	loot_size: 1
+	use_title: true
 	rewards: [
-		{ item: "refinedstorage:1k_storage_part", weight: 1000 }
-		{ item: "refinedstorage:4k_storage_part", weight: 100 }
-		{ item: "refinedstorage:16k_storage_part", weight: 10 }
+		{ item: "refinedstorage:1k_storage_part", weight: 1000.0f }
+		{ item: "refinedstorage:4k_storage_part", weight: 100.0f }
+		{ item: "refinedstorage:16k_storage_part", weight: 10.0f }
 		{ item: "refinedstorage:64k_storage_part" }
 	]
 }

--- a/config/ftbquests/quests/reward_tables/twilight_forest_loot_bag.snbt
+++ b/config/ftbquests/quests/reward_tables/twilight_forest_loot_bag.snbt
@@ -3,15 +3,16 @@
 	order_index: 9
 	title: "Twilight Forest Loot Bag"
 	loot_size: 1
+	use_title: true
 	rewards: [
-		{ item: "twilightforest:steeleaf_ingot", count: 2, random_bonus: 2, weight: 50 }
-		{ item: "twilightforest:knightmetal_ingot", count: 2, random_bonus: 2, weight: 25 }
-		{ item: "twilightforest:raw_ironwood", count: 2, random_bonus: 2, weight: 100 }
-		{ item: "twilightforest:fiery_blood", count: 2, random_bonus: 2, weight: 20 }
-		{ item: "twilightforest:hydra_chop", count: 2, random_bonus: 2, weight: 10 }
-		{ item: "twilightforest:cooked_venison", count: 4, random_bonus: 4, weight: 100 }
-		{ item: "twilightforest:charm_of_life_1", random_bonus: 1, weight: 50 }
-		{ item: "twilightforest:charm_of_keeping_1", random_bonus: 2, weight: 25 }
+		{ item: "twilightforest:steeleaf_ingot", count: 2, random_bonus: 2, weight: 50.0f }
+		{ item: "twilightforest:knightmetal_ingot", count: 2, random_bonus: 2, weight: 25.0f }
+		{ item: "twilightforest:raw_ironwood", count: 2, random_bonus: 2, weight: 100.0f }
+		{ item: "twilightforest:fiery_blood", count: 2, random_bonus: 2, weight: 20.0f }
+		{ item: "twilightforest:hydra_chop", count: 2, random_bonus: 2, weight: 10.0f }
+		{ item: "twilightforest:cooked_venison", count: 4, random_bonus: 4, weight: 100.0f }
+		{ item: "twilightforest:charm_of_life_1", random_bonus: 1, weight: 50.0f }
+		{ item: "twilightforest:charm_of_keeping_1", random_bonus: 2, weight: 25.0f }
 		{
 			item: {
 				id: "twilightforest:ore_magnet"
@@ -20,11 +21,11 @@
 					Damage: 0
 				}
 			}
-			weight: 2
+			weight: 2.0f
 		}
-		{ item: "twilightforest:reappearing_block", count: 3, random_bonus: 6, weight: 10 }
-		{ item: "twilightforest:transformation_powder", random_bonus: 2, weight: 25 }
-		{ item: "twilightforest:cicada", weight: 50 }
+		{ item: "twilightforest:reappearing_block", count: 3, random_bonus: 6, weight: 10.0f }
+		{ item: "twilightforest:transformation_powder", random_bonus: 2, weight: 25.0f }
+		{ item: "twilightforest:cicada", weight: 50.0f }
 		{
 			item: {
 				id: "twilightforest:ironwood_sword"
@@ -37,7 +38,7 @@
 					}]
 				}
 			}
-			weight: 20
+			weight: 20.0f
 		}
 		{
 			item: {
@@ -51,8 +52,8 @@
 					}]
 				}
 			}
-			weight: 5
+			weight: 5.0f
 		}
-		{ item: "twilightforest:cooked_meef", count: 4, random_bonus: 4, weight: 100 }
+		{ item: "twilightforest:cooked_meef", count: 4, random_bonus: 4, weight: 100.0f }
 	]
 }

--- a/config/ftbquests/quests/reward_tables/uncommon.snbt
+++ b/config/ftbquests/quests/reward_tables/uncommon.snbt
@@ -4,6 +4,7 @@
 	title: "&aUncommon Reward"
 	icon: "ftbquests:lootcrate"
 	loot_size: 1
+	use_title: true
 	rewards: [
 		{
 			item: {
@@ -15,9 +16,9 @@
 					coolDownTime: 472179L
 				}
 			}
-			weight: 5
+			weight: 5.0f
 		}
-		{ item: "mob_grinding_utils:saw", weight: 3 }
+		{ item: "mob_grinding_utils:saw", weight: 3.0f }
 		{
 			item: {
 				id: "modularrouters:distributor_module"
@@ -53,8 +54,8 @@
 			}
 		}
 		{ item: "modularrouters:speed_upgrade", count: 4, random_bonus: 4 }
-		{ item: "pipez:advanced_upgrade", random_bonus: 1, weight: 3 }
-		{ item: "pipez:universal_pipe", count: 8, random_bonus: 16, weight: 10 }
+		{ item: "pipez:advanced_upgrade", random_bonus: 1, weight: 3.0f }
+		{ item: "pipez:universal_pipe", count: 8, random_bonus: 16, weight: 10.0f }
 		{ item: "productivebees:upgrade_breeding" }
 		{ item: "mekanism:advanced_tier_installer" }
 		{
@@ -70,9 +71,9 @@
 					}
 				}
 			}
-			weight: 3
+			weight: 3.0f
 		}
-		{ item: "mekanismgenerators:wind_generator", weight: 5 }
+		{ item: "mekanismgenerators:wind_generator", weight: 5.0f }
 		{
 			item: {
 				id: "minecraft:enchanted_book"
@@ -103,10 +104,10 @@
 					Potion: "potionsmaster:diamond_sight"
 				}
 			}
-			weight: 5
+			weight: 5.0f
 		}
-		{ item: "mob_grinding_utils:golden_egg", weight: 2 }
-		{ item: "mob_grinding_utils:rotten_egg", weight: 2 }
+		{ item: "mob_grinding_utils:golden_egg", weight: 2.0f }
+		{ item: "mob_grinding_utils:rotten_egg", weight: 2.0f }
 		{
 			item: {
 				id: "ironjetpacks:jetpack"
@@ -126,7 +127,7 @@
 				tag: { }
 			}
 		}
-		{ item: "functionalstorage:gold_upgrade", weight: 2 }
+		{ item: "functionalstorage:gold_upgrade", weight: 2.0f }
 		{
 			item: {
 				id: "enderchests:ender_chest"
@@ -136,32 +137,21 @@
 					code: "000"
 				}
 			}
-			weight: 2
+			weight: 2.0f
 		}
 		{ item: "thermal:upgrade_augment_1" }
-		{ item: "sophisticatedbackpacks:void_upgrade", weight: 2 }
+		{ item: "sophisticatedbackpacks:void_upgrade", weight: 2.0f }
 		{ item: "dankstorage:dank_3" }
 		{ item: "apotheosis:vial_of_expulsion" }
 		{ item: "ars_nouveau:glyph_accelerate" }
 		{ item: "apotheosis:vial_of_extraction" }
 		{ item: "ars_nouveau:glyph_aoe" }
-		{ item: "reliquary:lantern_of_paranoia", weight: 2 }
-		{
-			item: {
-				id: "sophisticatedbackpacks:iron_backpack"
-				Count: 1b
-				tag: {
-					inventorySlots: 54
-					upgradeSlots: 2
-				}
-			}
-			weight: 3
-		}
-		{ item: "sophisticatedbackpacks:stack_upgrade_tier_1", weight: 5 }
-		{ item: "sophisticatedstorage:stack_upgrade_tier_1", weight: 5 }
+		{ item: "reliquary:lantern_of_paranoia", weight: 2.0f }
+		{ item: "sophisticatedbackpacks:stack_upgrade_tier_1", weight: 5.0f }
+		{ item: "sophisticatedstorage:stack_upgrade_tier_1", weight: 5.0f }
 		{ item: "compactmachines:machine_giant" }
-		{ item: "apotheosis:gem_dust", count: 2, random_bonus: 4, weight: 10 }
-		{ item: "sophisticatedstorage:void_upgrade", weight: 10 }
+		{ item: "apotheosis:gem_dust", count: 2, random_bonus: 4, weight: 10.0f }
+		{ item: "sophisticatedstorage:void_upgrade", weight: 10.0f }
 		{ item: "thermal:machine_insolator" }
 		{
 			item: {
@@ -171,21 +161,21 @@
 					woodType: "oak"
 				}
 			}
-			weight: 10
+			weight: 10.0f
 		}
 		{ item: "ars_nouveau:glyph_explosion" }
 		{ item: "productivebees:upgrade_simulator" }
-		{ item: "dankstorage:dank_2", weight: 5 }
-		{ item: "productivebees:upgrade_time", weight: 2 }
-		{ item: "minecraft:diamond", count: 3, random_bonus: 3, weight: 10 }
-		{ item: "minecraft:iron_ingot", count: 8, random_bonus: 8, weight: 20 }
-		{ item: "minecraft:gold_ingot", count: 4, random_bonus: 4, weight: 15 }
-		{ item: "minecraft:lapis_lazuli", count: 16, random_bonus: 8, weight: 20 }
-		{ item: "minecraft:iron_block", weight: 15 }
-		{ item: "minecraft:diamond_block", weight: 10 }
-		{ item: "minecraft:gold_block", weight: 12 }
-		{ item: "minecraft:redstone_block", random_bonus: 2, weight: 20 }
-		{ item: "minecraft:emerald_block", weight: 10 }
+		{ item: "dankstorage:dank_2", weight: 5.0f }
+		{ item: "productivebees:upgrade_time", weight: 2.0f }
+		{ item: "minecraft:diamond", count: 3, random_bonus: 3, weight: 10.0f }
+		{ item: "minecraft:iron_ingot", count: 8, random_bonus: 8, weight: 20.0f }
+		{ item: "minecraft:gold_ingot", count: 4, random_bonus: 4, weight: 15.0f }
+		{ item: "minecraft:lapis_lazuli", count: 16, random_bonus: 8, weight: 20.0f }
+		{ item: "minecraft:iron_block", weight: 15.0f }
+		{ item: "minecraft:diamond_block", weight: 10.0f }
+		{ item: "minecraft:gold_block", weight: 12.0f }
+		{ item: "minecraft:redstone_block", random_bonus: 2, weight: 20.0f }
+		{ item: "minecraft:emerald_block", weight: 10.0f }
 		{
 			item: {
 				id: "minecraft:potion"
@@ -194,7 +184,7 @@
 					Potion: "potionsmaster:diamond_sight"
 				}
 			}
-			weight: 5
+			weight: 5.0f
 		}
 		{
 			item: {
@@ -204,7 +194,7 @@
 					Potion: "potionsmaster:gold_sight"
 				}
 			}
-			weight: 10
+			weight: 10.0f
 		}
 		{
 			item: {
@@ -214,7 +204,7 @@
 					Potion: "potionsmaster:iron_sight"
 				}
 			}
-			weight: 15
+			weight: 15.0f
 		}
 		{
 			item: {
@@ -224,27 +214,27 @@
 					Potion: "potionsmaster:redstone_sight"
 				}
 			}
-			weight: 15
+			weight: 15.0f
 		}
-		{ item: "minecraft:netherite_scrap", random_bonus: 1, weight: 5 }
+		{ item: "minecraft:netherite_scrap", random_bonus: 1, weight: 5.0f }
 		{ item: "minecraft:netherite_ingot" }
-		{ item: "croptopia:toast", count: 2, random_bonus: 4, weight: 20 }
-		{ item: "croptopia:buttered_toast", count: 2, random_bonus: 4, weight: 7 }
-		{ item: "croptopia:avocado_toast", count: 2, random_bonus: 4, weight: 5 }
-		{ item: "delightful:deluxe_cheeseburger", weight: 5 }
-		{ item: "delightful:cheeseburger", random_bonus: 2, weight: 10 }
-		{ item: "farmersdelight:hamburger", random_bonus: 1, weight: 15 }
-		{ item: "croptopia:fruit_salad", weight: 5 }
-		{ item: "minecraft:redstone", count: 8, random_bonus: 16, weight: 15 }
-		{ item: "minecraft:lava_bucket", weight: 5 }
-		{ item: "mekanismgenerators:wind_generator", weight: 10 }
-		{ item: "powah:solar_panel_basic", weight: 10 }
-		{ item: "powah:thermo_generator_basic", weight: 5 }
-		{ item: "mekanismgenerators:gas_burning_generator", weight: 5 }
-		{ item: "functionalstorage:compacting_drawer", weight: 10 }
-		{ item: "functionalstorage:storage_controller", weight: 3 }
-		{ item: "minecraft:ender_pearl", count: 4, random_bonus: 4, weight: 10 }
-		{ item: "minecraft:ender_eye", random_bonus: 2, weight: 5 }
+		{ item: "croptopia:toast", count: 2, random_bonus: 4, weight: 20.0f }
+		{ item: "croptopia:buttered_toast", count: 2, random_bonus: 4, weight: 7.0f }
+		{ item: "croptopia:avocado_toast", count: 2, random_bonus: 4, weight: 5.0f }
+		{ item: "delightful:deluxe_cheeseburger", weight: 5.0f }
+		{ item: "delightful:cheeseburger", random_bonus: 2, weight: 10.0f }
+		{ item: "farmersdelight:hamburger", random_bonus: 1, weight: 15.0f }
+		{ item: "croptopia:fruit_salad", weight: 5.0f }
+		{ item: "minecraft:redstone", count: 8, random_bonus: 16, weight: 15.0f }
+		{ item: "minecraft:lava_bucket", weight: 5.0f }
+		{ item: "mekanismgenerators:wind_generator", weight: 10.0f }
+		{ item: "powah:solar_panel_basic", weight: 10.0f }
+		{ item: "powah:thermo_generator_basic", weight: 5.0f }
+		{ item: "mekanismgenerators:gas_burning_generator", weight: 5.0f }
+		{ item: "functionalstorage:compacting_drawer", weight: 10.0f }
+		{ item: "functionalstorage:storage_controller", weight: 3.0f }
+		{ item: "minecraft:ender_pearl", count: 4, random_bonus: 4, weight: 10.0f }
+		{ item: "minecraft:ender_eye", random_bonus: 2, weight: 5.0f }
 		{
 			item: {
 				id: "minecraft:enchanted_book"
@@ -329,12 +319,12 @@
 				}
 			}
 		}
-		{ item: "minecraft:quartz", count: 4, random_bonus: 4, weight: 10 }
-		{ item: "ae2:silicon", count: 2, random_bonus: 4, weight: 15 }
+		{ item: "minecraft:quartz", count: 4, random_bonus: 4, weight: 10.0f }
+		{ item: "ae2:silicon", count: 2, random_bonus: 4, weight: 15.0f }
 		{ item: "botania:mana_pool" }
-		{ item: "botania:manasteel_ingot", count: 2, random_bonus: 2, weight: 10 }
-		{ item: "botania:mana_diamond", random_bonus: 2, weight: 5 }
-		{ item: "botania:mana_pearl", random_bonus: 2, weight: 5 }
+		{ item: "botania:manasteel_ingot", count: 2, random_bonus: 2, weight: 10.0f }
+		{ item: "botania:mana_diamond", random_bonus: 2, weight: 5.0f }
+		{ item: "botania:mana_pearl", random_bonus: 2, weight: 5.0f }
 		{
 			item: {
 				id: "twilightforest:giant_sword"
@@ -354,19 +344,19 @@
 			}
 		}
 		{ item: "reliquary:pedestals/passive/white_passive_pedestal" }
-		{ item: "functionalstorage:oak_1", count: 4, random_bonus: 4, weight: 10 }
+		{ item: "functionalstorage:oak_1", count: 4, random_bonus: 4, weight: 10.0f }
 		{ item: "mob_grinding_utils:absorption_hopper" }
-		{ item: "botanypots:terracotta_hopper_botany_pot", count: 2, random_bonus: 2, weight: 10 }
-		{ item: "mysticalagriculture:imperium_essence", weight: 8 }
-		{ item: "mysticalagriculture:tertium_essence", random_bonus: 1, weight: 10 }
-		{ item: "mysticalagriculture:prudentium_essence", count: 2, random_bonus: 2, weight: 20 }
-		{ item: "functionalstorage:void_upgrade", random_bonus: 2, weight: 10 }
+		{ item: "botanypots:terracotta_hopper_botany_pot", count: 2, random_bonus: 2, weight: 10.0f }
+		{ item: "mysticalagriculture:imperium_essence", weight: 8.0f }
+		{ item: "mysticalagriculture:tertium_essence", random_bonus: 1, weight: 10.0f }
+		{ item: "mysticalagriculture:prudentium_essence", count: 2, random_bonus: 2, weight: 20.0f }
+		{ item: "functionalstorage:void_upgrade", random_bonus: 2, weight: 10.0f }
 		{ item: "sophisticatedbackpacks:stack_upgrade_tier_2" }
 		{ item: "sophisticatedstorage:stack_upgrade_tier_2" }
-		{ item: "minecraft:saddle", weight: 5 }
-		{ item: "minecraft:name_tag", weight: 5 }
-		{ item: "ironfurnaces:gold_furnace", weight: 3 }
-		{ item: "reliquary:fertile_lily_pad", random_bonus: 2, weight: 5 }
+		{ item: "minecraft:saddle", weight: 5.0f }
+		{ item: "minecraft:name_tag", weight: 5.0f }
+		{ item: "ironfurnaces:gold_furnace", weight: 3.0f }
+		{ item: "reliquary:fertile_lily_pad", random_bonus: 2, weight: 5.0f }
 		{
 			item: {
 				id: "buildinggadgets:gadget_exchanging"
@@ -392,6 +382,6 @@
 				}
 			}
 		}
-		{ item: "minecraft:wither_skeleton_skull", weight: 10 }
+		{ item: "minecraft:wither_skeleton_skull", weight: 10.0f }
 	]
 }


### PR DESCRIPTION
- Added Creative Questline
- Ported Thermal Chapter, reworked rewards and a few quests
- Added Alloys and Alloy Tools to Allthemodium, reworked some rewards
- Complete rework of Mystical Ag Chapter, added custom random rewards

**Fixes**
- Update Several Twilight Forest Quest descriptions: Fix for #1105 and added Torchberries to fix #1210
- Update AE2 Crystal Growth Accelerator quest: Fix for #1080
- Fix Requirements for ElementalCraft Rune Quests - Fix for #1015
- Fix Mekanism quest to accept "all forge sulfur dusts" - Fixes #997
- Changed Questline Titles to prep for future update
- Fix quest in RS for the Advanced Storage Housing to allow players to unlock the quest from either fluid or item storage parts, rather than needing both.
- Adjusted Random Rewards for balance
- Minor changes and updates to Tips and Tricks