### PR TITLE
Fix some typos and grammar in quests

### DIFF
--- a/config/ftbquests/quests/chapters/allthemodium.snbt
+++ b/config/ftbquests/quests/chapters/allthemodium.snbt
@@ -54,11 +54,11 @@
 			y: 1.0d
 			shape: "rsquare"
 			description: [
-				"The next step in our adventure to become (nearly) invincible."
+				"The next step in our adventure is to become (nearly) invincible."
 				""
 				"Find this rare ore in the Nether's Warped Forests and Crimson Forests between Y100 to Y123. "
 				""
-				"You can also find this ore is in any biome in the Other, between Y0 and Y20."
+				"You can also find this ore in any biome in the Other, between Y0 and Y20."
 			]
 			hide_dependency_lines: false
 			dependencies: ["5BDBE666E604FCAC"]
@@ -607,7 +607,7 @@
 			description: [
 				"The Teleport Pad is used to teleport to 2 dimensions added by the ATM pack."
 				""
-				"You can use it to get to the Mining Dimension by placing it in the overworld, then shift right clicking with an empty hand."
+				"You can use it to get to the Mining Dimension by placing it in the overworld, then shift right-clicking with an empty hand."
 				""
 				"To go to the Other, do the same thing but in the Nether."
 			]

--- a/config/ftbquests/quests/chapters/applied_energistics_2.snbt
+++ b/config/ftbquests/quests/chapters/applied_energistics_2.snbt
@@ -1073,7 +1073,7 @@
 			y: 1.5d
 			shape: "rsquare"
 			description: [
-				"Items are not the only things that can be stored in ME cells. &bME Fluid Storage Cells&f can store liquids such as water, lava and any variety of modded oils and fuels, just to give a few examples."
+				"Items are not the only things that can be stored in ME cells. &bME Fluid Storage Cells&f can store liquids such as water, lava, and any variety of modded oils and fuels, just to give a few examples."
 				""
 				"Note that all storage cells, regardless of what they're designed to store, only differ in terms of their housing; both item and fluid cells use the same kind of storage component to make."
 				""
@@ -1323,7 +1323,7 @@
 			shape: "rsquare"
 			subtitle: "Cut out the middleman"
 			description: [
-				"&bP2P&f (peer-to-peer) is a powerful system within AE2, allowing for the transfer of items, fluids and even more without the need for any intermediary ME storage."
+				"&bP2P&f (peer-to-peer) is a powerful system within AE2, allowing for the transfer of items, fluids, and even more without the need for any intermediary ME storage."
 				""
 				"Right-clicking on a P2P tunnel with certain items will &eattune&f the tunnel into one capable of transferring something else, such as items through pipes, energy through cables, redstone signals and (by default) even ME connections themselves."
 				""
@@ -1357,7 +1357,7 @@
 			description: [
 				"The &bME Storage Bus&f, when facing some external storage container, will allow the container to be used as though it were part of the ME network, allowing items to be taken out from the container or inserted into it purely via ME."
 				""
-				"Storage buses can be filtered and given specific priorities such that specific items will try to go to the attached storage first, however it will not retroactively move any filtered items from anywhere else in the network to its attached storage."
+				"Storage buses can be filtered and given specific priorities such that specific items will try to go to the attached storage first, however, it will not retroactively move any filtered items from anywhere else in the network to its attached storage."
 			]
 			dependencies: ["74FC0DDDB91DB172"]
 			id: "7EFBAF3E281D2EBE"
@@ -1447,7 +1447,7 @@
 			x: 13.0d
 			y: 2.5d
 			shape: "circle"
-			description: ["The &bOverflow Destruction Card&f is a cell upgrade that allows storage cells to delete (void) any items of a type already contained within them, when try to move into the cell and the cell is already full."]
+			description: ["The &bOverflow Destruction Card&f is a cell upgrade that allows storage cells to delete (void) any items of a type already contained within them when trying to move into the cell and the cell is already full."]
 			dependencies: ["2F556E7919582D2D"]
 			id: "33ADE41526C39AFD"
 			tasks: [{
@@ -1472,7 +1472,7 @@
 			x: 17.5d
 			y: 2.5d
 			description: [
-				"&bPortable Cells&f function identically to regular cells in that they can they be inserted into a chest or drive and filled accordingly."
+				"&bPortable Cells&f function identically to regular cells in that they can be inserted into a chest or drive and filled accordingly."
 				""
 				"However, unlike regular cells, their contents can also be accessed standalone via the cell item itself, a bit like a digital ME-flavoured backpack."
 			]
@@ -1535,7 +1535,7 @@
 			shape: "rsquare"
 			subtitle: "This has a use outside of crafting cables."
 			description: [
-				"An important concept within AE2 is a technique known as \"&esubnetting&f\", wherein an extra separate ME network (a &esubnetwork&f) acts in conjuction with the main network to perform some specialised function or process."
+				"An important concept within AE2 is a technique known as \"&esubnetting&f\", wherein an extra separate ME network (a &esubnetwork&f) acts in conjunction with the main network to perform some specialised function or process."
 				""
 				"What separates a subnetwork from a completely detached separate network is usually the use of the &bQuartz Fiber&f as a cable part. When placed between two otherwise unconnected lengths of cable, the Quartz Fiber transfers no data or channels between the two whatsoever, instead only transmitting power."
 				""
@@ -1673,7 +1673,7 @@
 			description: [
 				"Individual ME devices can also be configured to respond to redstone signals. When upgraded with a &bRedstone Card&f, a device can be configured to do work only when powered with redstone or otherwise as needed."
 				""
-				"This behavour can also apply to entire &osections&r of an ME network by using an &bME Toggle Bus&f. This allows a section of the network on the other side of the bus to come online only when the bus is powered by redstone, or to go offline if using an &einverted&f toggle bus."
+				"This behaviour can also apply to entire &osections&r of an ME network by using an &bME Toggle Bus&f. This allows a section of the network on the other side of the bus to come online only when the bus is powered by redstone, or to go offline if using an &einverted&f toggle bus."
 			]
 			dependencies: ["3DDB0DDA7571B2C1"]
 			id: "1AAF0B31B47AF23D"
@@ -2040,7 +2040,7 @@
 				""
 				"Cable Anchors can also be used to craft &bCable Facades&f, allowing you to disguise cables within walls by covering them with the face of an arbitrary block. While facade recipes are hidden in JEI, you can still craft them by taking any regular block and surrounding it with 4 cable anchors in the crafting grid."
 				""
-				"Aside from crafting anchors, the cutting knife also has another use: right-clicking with the knife will open a small GUI that allows you craft &bInscriber Name Presses&f. When given a name, these presses can be used inside of an Inscriber to rename any input item with the name of the press. Two of these presses can be concatenated in the inscriber to rename the item to the name of the top press, followed by the bottom one."
+				"Aside from crafting anchors, the cutting knife also has another use: right-clicking with the knife will open a small GUI that allows you to craft &bInscriber Name Presses&f. When given a name, these presses can be used inside of an Inscriber to rename any input item with the name of the press. Two of these presses can be concatenated in the inscriber to rename the item to the name of the top press, followed by the bottom one."
 			]
 			dependencies: ["5C22E3103544B120"]
 			id: "6144202A97C6CD1C"
@@ -2496,7 +2496,7 @@
 			description: [
 				"In Applied Energistics 2, every ME network has a certain number of &echannels&f available, which simply means how many networked devices can fit on the whole network."
 				""
-				"As a rule of thumb, any device that more or less handles ME data directly (items stored within the network) and carries out some form of I/O will take up a channel. Usually components that are only concerned with the internal power storage of the network, like &eEnergy Cells&f and &eInscribers&f, do &onot&r take up channels."
+				"As a rule of thumb, any device that more or less handles ME data directly (items stored within the network) and carries out some form of I/O will take up a channel. Usually, components that are only concerned with the internal power storage of the network, like &eEnergy Cells&f and &eInscribers&f, do &onot&r take up channels."
 				""
 				"Networks without an &bME Controller&f are known as \"ad-hoc\" networks and only support a maximum of 8 channels."
 			]

--- a/config/ftbquests/quests/chapters/ars_nouveau.snbt
+++ b/config/ftbquests/quests/chapters/ars_nouveau.snbt
@@ -1885,7 +1885,7 @@
 			description: [
 				"This is the next upgrade to your Spellbook!"
 				""
-				"This will increase your overall mana and mana regen, as well as unlocking the ability to create and use Tier 2 Glyphs."
+				"This will increase your overall mana and mana regen, as well as unlock the ability to create and use Tier 2 Glyphs."
 			]
 			dependencies: ["64D0E66CB4FBEC82"]
 			id: "0D330FAD6C993DBC"
@@ -3095,7 +3095,7 @@
 				""
 				"The &6Jar of Voiding&r destroys items you pick up in exchange for mana. This can be filtered."
 				""
-				"To add or remove an item to be detroyed by the jar, use the jar with the item in your off hand, or use an item on the Scribe's Table with the jar placed on it."
+				"To add or remove an item to be destroyed by the jar, use the jar with the item in your off-hand, or use an item on the Scribe's Table with the jar placed on it."
 				""
 				"The jar must be on your hotbar to function."
 			]

--- a/config/ftbquests/quests/chapters/basic_power.snbt
+++ b/config/ftbquests/quests/chapters/basic_power.snbt
@@ -267,7 +267,7 @@
 		{
 			dependencies: ["1F81EA5E45424308"]
 			description: [
-				"Mekanism offers a nice looking cable to transfer your power."
+				"Mekanism offers a nice-looking cable to transfer your power."
 				""
 				"If the machine you are connecting to already pulls or pushes power, you will not need to configure the cable. Otherwise, you'll need a &9Configurator&r to configure the pipe. Shift+right-clicking will change the cable to pull or push mode. "
 			]
@@ -821,7 +821,7 @@
 				""
 				"You can even charge your jetpack while you are flying with this mod. HOW COOL IS THAT?"
 				""
-				"To get started with the mod, you'll need some Flux Dust. Head to bedrock level, then throw some redstone on top of a block of bedrock. Place a block of obsidian right above the floating redstone, then left click the obsidian."
+				"To get started with the mod, you'll need some Flux Dust. Head to bedrock level, then throw some redstone on top of a block of bedrock. Place a block of obsidian right above the floating redstone, then left-click the obsidian."
 			]
 			id: "35CC898E0E49FE58"
 			min_width: 300
@@ -901,7 +901,7 @@
 				""
 				"The Plug is used to \"draw\" power from the block it is attached to. Aside from a small buffer, the Plug does not store power itself, so don't worry about it zapping up all of your power."
 				""
-				"It is suggested to place the Plug on a power storage block like an energy cube. It can connect to cables, pipes, or the output of any power producing machine."
+				"It is suggested to place the Plug on a power storage block like an energy cube. It can connect to cables, pipes, or the output of any power-producing machine."
 				""
 				"To learn how to set up your first network, check the next quest!"
 			]
@@ -972,7 +972,7 @@
 			description: [
 				"With our plug set up, we can now tap into the power from our network. The &9Flux Point&r does exactly that. It points the power from your network to whatever block it is attached to, including pipes or cables, or just directly on machines!"
 				""
-				"Once you've placed your point on the machine or block you want to power, right click on it and select your network in the Network Selection tab. Just like the plug, you can adjust how much power it pulls, priority level, etc."
+				"Once you've placed your point on the machine or block you want to power, right-click on it and select your network in the Network Selection tab. Just like the plug, you can adjust how much power it pulls, priority level, etc."
 			]
 			id: "56B6ABF3D6EA0D84"
 			rewards: [
@@ -1038,7 +1038,7 @@
 		{
 			dependencies: ["36DEA17CBB696CC7"]
 			description: [
-				"Right clicking a functional Flux Network block will give you this UI."
+				"Right-clicking a functional Flux Network block will give you this UI."
 				""
 				"Each Plug or Point can be named, have a custom priority level, and have a custom power transfer limit. This allows complete control over all parts of your system."
 				""
@@ -1074,7 +1074,7 @@
 				""
 				"Once you have a Plug attached to your power system, you'll want to make the &9Flux Controller&r and place it down."
 				""
-				"Right click to bring up the interface, and go to the \"Wireless Charging\" tab. From here, you can select each section of your inventory you'd like to keep charged. To activate, make sure to hit the toggle at the bottom to Enable Wireless charging, then click apply!"
+				"Right-click to bring up the interface, and go to the \"Wireless Charging\" tab. From here, you can select each section of your inventory you'd like to keep charged. To activate, make sure to hit the toggle at the bottom to Enable Wireless charging, then click apply!"
 				""
 				"{image:atm:textures/questpics/flux/wireless_ui.png width:125 height:150 align:1}"
 			]

--- a/config/ftbquests/quests/chapters/bigger_reactors.snbt
+++ b/config/ftbquests/quests/chapters/bigger_reactors.snbt
@@ -256,7 +256,7 @@
 				""
 				"The &cPower Tap&r provides a way for you to \"tap\" into the power that a &9passive&r reactor makes. You can attach pipes and cables to extract the power from it."
 				""
-				"The &aAccess Ports&r are required for every reactor, and allows you to both input fuel (Uranium) from the reactor, or extract waste (Cyanite). While it only requires one, it's usually a good idea to have 2 per reactor. If the inventory can push &land&r pull (i.e. hopper), Cyanite will be pushed into the inventory as an input."
+				"The &aAccess Ports&r are required for every reactor, and allow you to both input fuel (Uranium) from the reactor, or extract waste (Cyanite). While it only requires one, it's usually a good idea to have 2 per reactor. If the inventory can push &land&r pull (i.e. hopper), Cyanite will be pushed into the inventory as an input."
 			]
 			dependencies: ["4B9E9497E44D0096"]
 			id: "2A20000FAEC2E16A"
@@ -941,7 +941,7 @@
 			description: [
 				"Instead of building the smallest Turbine at this point, it's better to build a Turbine based off of the design of your &9Active Reactor&r."
 				""
-				"For starters, you want to build a Turbine that can handle the &9Exhaust Flow Rate&r of your reactor. To get the most power out of it, it'll need to maintain 1800RPM as well. This takes a lot of experimenting with different coils, # of blades, and overall size of the Turbine!"
+				"For starters, you want to build a Turbine that can handle the &9Exhaust Flow Rate&r of your reactor. To get the most power out of it, it'll need to maintain 1800RPM as well. This takes a lot of experimenting with different coils, # of blades, and the overall size of the Turbine!"
 				""
 				"Note: To complete this quest, you'll need to create a &dTask Screen&r of any size. Once placed, you can right-click the screen and select this quest as the requirement, then output power into the task screen block to fill it up and complete the quest."
 				""

--- a/config/ftbquests/quests/chapters/blue_skies.snbt
+++ b/config/ftbquests/quests/chapters/blue_skies.snbt
@@ -737,7 +737,7 @@
 			y: 3.5d
 			shape: "rsquare"
 			description: [
-				"This is used to upgrade and enchance tools from Blue Skies."
+				"This is used to upgrade and enhance tools from Blue Skies."
 				""
 				"You can use Falsite to increase the durability of a tool, or you can use any stick from the mod to swap out on a tool. Yes, different wood types have different uses."
 			]
@@ -848,7 +848,7 @@
 			description: [
 				"Ever wanted a forge that just smelts things without fuel?"
 				""
-				"Me too. Technically, this does need a \"fuel\" per-se. It has a charge, and can be recharged using Sunstone or anything made from Horizonite."
+				"Me too. Technically, this does need a \"fuel\" per se. It has a charge, and can be recharged using Sunstone or anything made from Horizonite."
 				""
 				"The forge must be empty to recharge."
 			]
@@ -1391,7 +1391,7 @@
 				""
 				"Gather some Nature Dungeon Keys within the maze of the structure to unlock the boss fight, and CHOP him down!"
 				""
-				"Note: You can trade with the Gatekeeper in case you can't find all of the keys, but only after you right click the gate for the boss fight."
+				"Note: You can trade with the Gatekeeper in case you can't find all of the keys, but only after you right-click the gate for the boss fight."
 				""
 				"{image:atm:textures/questpics/blueskies/blueskies_everbright_naturedungeon.png width:200 height:150 align:1}"
 			]

--- a/config/ftbquests/quests/chapters/botania.snbt
+++ b/config/ftbquests/quests/chapters/botania.snbt
@@ -564,7 +564,7 @@
 				""
 				"To create items, just throw the appropriate items for the recipe into the Apothecary. Right clicking with an empty hand will remove items from it as well."
 				""
-				"Once a recipe has been completed, you will have about 20 seconds where &aright clicking with an empty hand&r will refill the last recipe, making it easier to create multiple of the same items!"
+				"Once a recipe has been completed, you will have about 20 seconds where &aright-clicking with an empty hand&r will refill the last recipe, making it easier to create multiple of the same items!"
 			]
 			id: "79BE48D56622542F"
 			min_width: 250
@@ -2262,7 +2262,7 @@
 				""
 				"The higher the amount of Mana stored in the tool, the higher the rank that it has, with D being the lowest and SS being the highest."
 				""
-				"Increasing the tool's rank does not increase the speed of it, but instead increases the AoE of its &bActive Ability&r, which can be toggled on and off by sneak-right clicking. When active, it increases the Shatterer's mining width and height based on the rank. Being at a rank of D will not have an ability."
+				"Increasing the tool's rank does not increase its speed, but instead increases the AoE of its &bActive Ability&r, which can be toggled on and off by sneak-right clicking. When active, it increases the Shatterer's mining width and height based on the rank. Being at a rank of D will not have an ability."
 				""
 				"Note: As long as the tool is active, it will consume its stored mana."
 			]
@@ -2364,7 +2364,7 @@
 			description: [
 				"&9Runes&r are vital crafting components in many of the more advanced recipes in Botania, and these are created on a &aRunic Altar&r."
 				""
-				"To use the Altar, start by placing the components of the rune you want on it. This can be done either by right clicking or dropping the item. It will also need Mana, so make sure to point a Mana Spreader that is getting Mana towards it as well."
+				"To use the Altar, start by placing the components of the rune you want on it. This can be done either by right-clicking or dropping the item. It will also need Mana, so make sure to point a Mana Spreader that is getting Mana towards it as well."
 				""
 				"Once you've finished placing the items, you can hover over the Altar with your wand and it will show you the progress of the recipe. When it completes, drop a piece of Livingrock on the Altar, then use your wand to collect your rune."
 				""
@@ -2716,7 +2716,7 @@
 				""
 				"Once the frame is created, we'll need to open it by using at least &d2 Mana Pools&r, a huge amount of mana, and a &aNatura Pylon&r over the 2 pools. These mana pools can be within an 11x11x11 area around the core."
 				""
-				"With everything set up, right click the Elven Core with your wand to activate the portal."
+				"With everything set up, right-click the Elven Core with your wand to activate the portal."
 				""
 				"Note: Even though the Mana Pools need a large amount of Mana to activate the portal, activating the portal does not cost Mana itself. However, converting materials over will use a little each time. If there is not enough mana, the portal will close."
 				""
@@ -2886,7 +2886,7 @@
 		{
 			dependencies: ["3A20210242A1C865"]
 			description: [
-				"Has an ability to clear away Cobblestone, Dirt, Netherrack, and other common materials, leaving behind only ores and fine resources."
+				"Has the ability to clear away Cobblestone, Dirt, Netherrack, and other common materials, leaving behind only ores and fine resources."
 				""
 				"Can combine with the Terra Shatterer in a crafting grid, which will allow the latter to take on the former's power. This cannot be undone."
 			]
@@ -3223,7 +3223,7 @@
 			description: [
 				"With Botania, you can create a &dCorporea Network&r by using &9Corporea Sparks&r over inventories."
 				""
-				"While the network will need at least one &bMaster&r &9Corporea Spark&r to work, you can expand the network with as many Corporea Sparks as you want. When these Sparks are placed, it will connect to all of the same colored Corporea Sparks and form an item network. Each Spark only has a range of 8 blocks."
+				"While the network will need at least one &bMaster&r &9Corporea Spark&r to work, you can expand the network with as many Corporea Sparks as you want. When these Sparks are placed, they will connect to all of the same colored Corporea Sparks and form an item network. Each Spark only has a range of 8 blocks."
 				""
 				"These Sparks can only see the inventory directly beneath it, but can only access items from its top side. Each Spark can also see every item in the Corporea network, and can be accessed by other Corporea blocks, like the Funnel or Index."
 			]
@@ -3286,7 +3286,7 @@
 		}
 		{
 			dependencies: ["634E71DBAE81D197"]
-			description: ["The &9Corporea Crystal Cube&r is used to show the total count of an item in the Corporea Network of the Spark placed above it by right clicking it with that item."]
+			description: ["The &9Corporea Crystal Cube&r is used to show the total count of an item in the Corporea Network of the Spark placed above it by right-clicking it with that item."]
 			id: "7440E522FC31C341"
 			optional: true
 			rewards: [{
@@ -3920,7 +3920,7 @@
 				"6FBE0BF8A7ADBB26"
 				"3A20210242A1C865"
 			]
-			description: ["Using this on a Spreader will cause it to only fire a Mana Burst only if it can hit a mob or player."]
+			description: ["Using this on a Spreader will cause it to fire a Mana Burst only if it can hit a mob or player."]
 			hide_dependency_lines: true
 			id: "0E7E559F2750F7D3"
 			optional: true

--- a/config/ftbquests/quests/chapters/elementalcraft.snbt
+++ b/config/ftbquests/quests/chapters/elementalcraft.snbt
@@ -90,9 +90,9 @@
 			x: 4.5d
 			y: -1.0d
 			description: [
-				"The &eelement extractor&f will extract element out of the element sources that are generated throughout the world. The extractor must be placed directly below the source while also on top of an &eelement container&f."
+				"The &eelement extractor&f will extract elements out of the element sources that are generated throughout the world. The extractor must be placed directly below the source while also on top of an &eelement container&f."
 				""
-				"The &eelement evaporator&f turns elemental shards into element. Must be placed ontop of a container"
+				"The &eelement evaporator&f turns elemental shards into elements. Must be placed on top of a container"
 			]
 			dependencies: ["5E029A2BA469F42D"]
 			id: "023C2C0632BC0934"

--- a/config/ftbquests/quests/chapters/evilcraft.snbt
+++ b/config/ftbquests/quests/chapters/evilcraft.snbt
@@ -1601,7 +1601,7 @@
 		}
 		{
 			dependencies: ["35FA55BE8DF49EE8"]
-			description: ["To insert the desired potion, just right click with the &2Primed Pendant&r in hand to open its inventory."]
+			description: ["To insert the desired potion, just right-click with the &2Primed Pendant&r in hand to open its inventory."]
 			hide_dependency_lines: true
 			id: "4DF7E2149F4BD8CC"
 			rewards: [

--- a/config/ftbquests/quests/chapters/food_and_farming.snbt
+++ b/config/ftbquests/quests/chapters/food_and_farming.snbt
@@ -305,7 +305,7 @@
 			shape: "rsquare"
 			subtitle: "The villager has more than one way to spawn"
 			description: [
-				"Markets provide you with a villager than can sell you anything, if you have the right amount of emeralds."
+				"Markets provide you with a villager than can sell you anything if you have the right amount of emeralds."
 				""
 				"Spoiler: It's usually just 1 Emerald per item. BUT THEY HAVE EVERYTHING."
 			]
@@ -790,7 +790,7 @@
 			description: [
 				"Stores items in the multi-block kitchen. Stack them on top of each other!"
 				""
-				"You can also shift-right click on it to open then door, and you can just right click items right in."
+				"You can also shift-right-click on it to open the door, and you can just right-click items right in."
 			]
 			hide_dependency_lines: true
 			dependencies: ["28C9EDBF6607E180"]

--- a/config/ftbquests/quests/chapters/hostile_neural_networks.snbt
+++ b/config/ftbquests/quests/chapters/hostile_neural_networks.snbt
@@ -153,7 +153,7 @@
 			description: [
 				"The &dSimulation Chamber&r is the main machine within HNN."
 				""
-				"When given power, it will run simulations based on the &bData Model&r that is placed inside. The power required also depends on the Data Model placed inside, and can be seen within the Model's tooltip. "
+				"When given power, it will run simulations based on the &bData Model&r that is placed inside. The power required also depends on the Data Model placed inside and can be seen within the Model's tooltip. "
 				""
 				"The machine also requires at least one &9Prediction Matrix&r to run a simulation."
 				""

--- a/config/ftbquests/quests/chapters/main_chapter1.snbt
+++ b/config/ftbquests/quests/chapters/main_chapter1.snbt
@@ -644,7 +644,7 @@
 				count: 2L
 			}]
 			description: [
-				"These work like pressure plates. Right click them to get a shard that you can use on another warp plate to link them."
+				"These work like pressure plates. Right-click them to get a shard that you can use on another warp plate to link them."
 				""
 				"If you need to create another Attuned Shard, place flint in the center and surround with 4 warp dust."
 			]
@@ -1295,7 +1295,7 @@
 				""
 				"Use the command &a/ftbteams party create&r to create your team."
 				""
-				"To claim chunks, the default key to open the Claim Map is \"M\". To claim a chunk, left click and drag to claim. To force load a chunk, shift-left click the chunk. If done properly, you'll see lines across the chunk."
+				"To claim chunks, the default key to open the Claim Map is \"M\". To claim a chunk, left-click and drag to claim. To force load a chunk, shift-left click the chunk. If done properly, you'll see lines across the chunk."
 			]
 			id: "5E7C6705CE996BDF"
 			x: 2.0d
@@ -1315,9 +1315,9 @@
 				count: 8L
 			}]
 			description: [
-				"You can break down Charcoal AND Coal into tiny pieces, which smelt 1 item a piece."
+				"You can break down Charcoal AND Coal into tiny pieces, which smelt 1 item apiece."
 				""
-				"No more left over fuel burning!"
+				"No more leftover fuel burning!"
 			]
 			id: "008BA27244838C81"
 			x: 0.0d

--- a/config/ftbquests/quests/chapters/main_chapter2.snbt
+++ b/config/ftbquests/quests/chapters/main_chapter2.snbt
@@ -238,7 +238,7 @@
 			description: [
 				"Use the parts from the previous quest to create your first Wind Generator!"
 				""
-				"Wind Generators need to be placed in view of the sky, and the higher they are placed, the more power it generates!"
+				"Wind Generators need to be placed in view of the sky, and the higher they are placed, the more power they generate!"
 				""
 				"*Note: If the noise is too much, you can install the muffling upgrade into the Generator."
 			]
@@ -298,7 +298,7 @@
 				""
 				"Go ahead and make yourself some Energy Pipez and a Pipe Wrench. You'll need the pipe wrench to get the pipe to extract power."
 				""
-				"*Note: To tell the pipe to \"extract\" the power, shift right click on the pipe connected to the Wind Generator."
+				"*Note: To tell the pipe to \"extract\" the power, shift right-click on the pipe connected to the Wind Generator."
 				""
 			]
 			id: "343AEA9974EBCAD8"
@@ -339,7 +339,7 @@
 			description: [
 				"You can get early game flight by creating a Wooden Jetpack!"
 				""
-				"This is the starter jetpack, and only stores a very tiny amount of power. Make sure to upgrade it quickly!"
+				"This is the starter jetpack and only stores a very tiny amount of power. Make sure to upgrade it quickly!"
 			]
 			id: "201143A8D039A543"
 			x: 4.0d
@@ -597,7 +597,7 @@
 			description: [
 				"All Pipez can be upgraded with pipe upgrades."
 				""
-				"To add the pipe upgrade, shift right click on the pipe that is currently set to extract."
+				"To add the pipe upgrade, shift right-click on the pipe that is currently set to extract."
 			]
 			id: "496A2D0AD494A942"
 			x: 4.5d
@@ -893,7 +893,7 @@
 				""
 				"The best place to farm Ender Pearls is in the End.... but before that, you can head to the Warped Forests of the Nether to farm Enderman."
 				""
-				"Once you've made enough Ender Eyes, right click them in the overworld and they'll lead you to a Stronghold."
+				"Once you've made enough Ender Eyes, right-click them in the overworld and they'll lead you to a Stronghold."
 			]
 			id: "1B47EE1C29C4AD73"
 			x: 21.0d
@@ -929,7 +929,7 @@
 				criterion: ""
 			}]
 			description: [
-				"If you're reading this, you are probably either looking for the End Portal in the End Fortress, and can't find it...."
+				"If you're reading this, you are probably either looking for the End Portal in the End Fortress and can't find it...."
 				""
 				"Or you already found it. Congrats!"
 			]
@@ -1386,7 +1386,7 @@
 			description: [
 				"The Teleport Pad is used to teleport to 2 dimensions added by the ATM pack."
 				""
-				"You can use it to get to the Mining Dimension by placing it in the overworld, then shift right clicking with an empty hand."
+				"You can use it to get to the Mining Dimension by placing it in the overworld, then shift right-clicking with an empty hand."
 				""
 				"To go to the Other, do the same thing but in the Nether."
 			]
@@ -1510,7 +1510,7 @@
 			description: [
 				"Maybe you've already stumbled upon the &dDeep Dark&r in your mining adventures. Maybe you're still looking for it."
 				""
-				"To help you find it, make yourself a &eNature's Compass&r. You can right click with it, type in the biome you are looking for, and it'll search for it for you."
+				"To help you find it, make yourself a &eNature's Compass&r. You can right-click with it, type in the biome you are looking for, and it'll search for it for you."
 			]
 			icon: "minecraft:sculk_sensor"
 			id: "101EF1ECBAD423C1"

--- a/config/ftbquests/quests/chapters/mekanism.snbt
+++ b/config/ftbquests/quests/chapters/mekanism.snbt
@@ -1311,7 +1311,7 @@
 				"407EFAF528871014"
 			]
 			description: [
-				"This machine \"Purifies\" our ores. It turns 1 Raw Ore into 2 \"Clumps\", which can then be sent through a Crusher to be turned to dirty dusts, then through an Enrichment Chamber to get clean dust, then through a smelter to be turned to an ingot."
+				"This machine \"Purifies\" our ores. It turns 1 Raw Ore into 2 \"Clumps\", which can then be sent through a Crusher to be turned to dirty dusts, then through an Enrichment Chamber to get clean dust, and then through a smelter to be turned to an ingot."
 				""
 				"This will double your ingot output."
 				""
@@ -1705,7 +1705,7 @@
 				""
 				"There are several methods to increase the temperature of the plant, including building them in a desert!"
 				""
-				"The &aFuelwood Heater&r burns buckets of Lava, which can them be piped in using a pipe that transfers heat."
+				"The &aFuelwood Heater&r burns buckets of Lava, which can then be piped in using a pipe that transfers heat."
 				""
 				"The &aResistive Heater&r uses RF/FE to produce heat, and can be set to use whatever RF/FE you want it to use."
 			]
@@ -2369,7 +2369,7 @@
 			description: [
 				"Mekanism is a tech mod that will change the way you play Minecraft."
 				""
-				"The mod focuses on breaking down materials to their chemical makeup, and getting the best out of every material you come across. "
+				"The mod focuses on breaking down materials to their chemical makeup and getting the best out of every material you come across. "
 				""
 				"This mod features Hydrogen-Powered Jetpacks, a mini-robotic friend, reactors, a Digital Miner to automate mining, and much, much more."
 			]
@@ -2566,7 +2566,7 @@
 			description: [
 				"When Bio Fuel is combined with Water and Hydrogen in a &aPressurized Reaction Chamber&r it creates Substrates. It also creates Ethylene as a by-product."
 				""
-				"These are needed to create HDPE pellets, which is used for end-game crafts like the Meka-suit."
+				"These are needed to create HDPE pellets, which are used for end-game crafts like the Meka-suit."
 			]
 			id: "5047792C6EF6D2AD"
 			rewards: [

--- a/config/ftbquests/quests/chapters/mekanism_reactors.snbt
+++ b/config/ftbquests/quests/chapters/mekanism_reactors.snbt
@@ -591,7 +591,7 @@
 				""
 				"The easiest way to do this is by giving the Reactor &9Water&r from a Sink. The Sink is an infinite water source, which is &oreally nice for a situation like this&r."
 				""
-				"Pump out the water into one of the Reactor's Ports that is set to &ainput&r to fill up the Reactor with water. This will be heated while the Reactor is running and get converted to &bSteam&r, which you can use to create power with in an &9Industrial Turbine&r."
+				"Pump out the water into one of the Reactor's Ports that is set to &ainput&r to fill up the Reactor with water. This will be heated while the Reactor is running and get converted to &bSteam&r, which you can use to create power within an &9Industrial Turbine&r."
 				""
 				"&eSodium&r can also be used as a much more efficient coolant. This allows for higher burn rates and lower core temperatures."
 			]
@@ -620,9 +620,9 @@
 				"3F5010269469EBE0"
 			]
 			description: [
-				"Once you've finish placing in all of the required blocks to build the Reactor, it should give off red particles to show that it is complete."
+				"Once you've finished placing in all of the required blocks to build the Reactor, it should give off red particles to show that it is complete."
 				""
-				"Right clicking anywhere on the Reactor will open up the &aInterface&r. This will have all of the information you need to run the Reactor properly, as well as two buttons to turn on and off the Reactor."
+				"Right-clicking anywhere on the Reactor will open up the &aInterface&r. This will have all of the information you need to run the Reactor properly, as well as two buttons to turn on and off the Reactor."
 				""
 				"On the left, you have 2 tanks: One for &bCoolant&r and one for &3Fissile Fuel&r. On the right, you have one for &8Nuclear Waste&r, and one for &bHeated Coolant&r, which will most likely be &bSteam&r."
 				""
@@ -1028,7 +1028,7 @@
 			description: [
 				"&8Nuclear Waste&r can be sent into an Isotopic Centrifuge to create &9Plutonium&r."
 				""
-				"Sending the Plutonium into a Pressurized Reaction Chamber with some water and &7Fluorite Dust&r will give you &9Plutonium Pellets&r. These are used to make end game materials!"
+				"Sending the Plutonium into a Pressurized Reaction Chamber with some water and &7Fluorite Dust&r will give you &9Plutonium Pellets&r. These are used to make end-game materials!"
 				""
 				"Note: This will also create a byproduct of &7Spent Nuclear Waste&r, which needs to be pumped into a Waste Barrel for storage."
 			]
@@ -1159,7 +1159,7 @@
 				"To build the Fusion Reactor, we need to follow a simple pattern. Each face will look like this:"
 				"{image:atm:textures/questpics/mek/fusion_pattern.png width:175 height:175 align:1}"
 				""
-				"For the top, we want replace the middle block with the Fusion Reactor Controller."
+				"For the top, we want to replace the middle block with the Fusion Reactor Controller."
 				""
 				"For the ports, you can replace any of the Reactor Glass on the sides. For this setup, we'll need two ports to input &cDeuterium&r and &eTritium&r, then a port to output power. "
 				""
@@ -1339,7 +1339,7 @@
 				""
 				"The goal is to aim each Laser into a Laser Amplifier. Using one is pretty slow, so we're going to make a few."
 				""
-				"In the image below, you can see an example of how this is setup. Sticking the Lasers directly on a power source like an Energy Cube works, or you can have them on pipes or cables. You want to give it a block of empty space between the lasers and the Laser Amplifier."
+				"In the image below, you can see an example of how this is set up. Sticking the Lasers directly on a power source like an Energy Cube works, or you can have them on pipes or cables. You want to give it a block of empty space between the lasers and the Laser Amplifier."
 				""
 				"The Laser Amplifier has a red dot on one of the faces. This is what you want to point towards the Laser Focus Matrix."
 				""
@@ -1459,7 +1459,7 @@
 				"4ABF0727AA569DD9"
 			]
 			description: [
-				"To kick start the Fusion Reactor, we'll need a quick-shot of D-T fuel. This is made by combining &cDeuterium&r and &eTritium&r together in a Chemical Infuser."
+				"To kick start the Fusion Reactor, we'll need a quick shot of D-T fuel. This is made by combining &cDeuterium&r and &eTritium&r together in a Chemical Infuser."
 				""
 				"Start by making a &4Hohlraum&r and place it into the Infuser (where the plus symbol is) to fill it with D-T fuel. Now we're ready to jumpstart the Reactor!"
 			]
@@ -1718,7 +1718,7 @@
 			description: [
 				"&9Turbine Valves&r are used to pump in &bSteam&r, as well as pumping out the power that the Turbine creates."
 				""
-				"&8Turbine Vents&r are used to pump out excess water when using &aSaturating Condensers&r. Otherwise, these help increase the overall flow of steam within the Turbine. The total number of Vents also limit the total Steam Flow Rate. Vents can also be used on the top face of the Turbine, but for this build, we'll just be using them on the outside faces."
+				"&8Turbine Vents&r are used to pump out excess water when using &aSaturating Condensers&r. Otherwise, these help increase the overall flow of steam within the Turbine. The total number of Vents also limits the total Steam Flow Rate. Vents can also be used on the top face of the Turbine, but for this build, we'll just be using them on the outside faces."
 				""
 				"&aSaturating Condensers&r are used to convert &bSteam&r back into water. These are placed on or above the layer containing the Electromagnetic Coils."
 			]
@@ -1767,7 +1767,7 @@
 			description: [
 				"The &9Turbine Rotor&r is placed in the middle of the Turbine. For every Turbine Rotor, you will need 2 &aTurbine Blades&r. For this Turbine, we'll be using 3 Rotors."
 				""
-				"While looking at the Rotor, right clicking with &aTurbine Blades&r will place them directly onto the Rotor. The taller the Rotor, the longer the Blades will become. For this build, we are using 6 total Blades. If you plan on building a bigger Turbine, you will need to increase the width of the Turbine depending on how many Blades you plan on using."
+				"While looking at the Rotor, right-clicking with &aTurbine Blades&r will place them directly onto the Rotor. The taller the Rotor, the longer the Blades will become. For this build, we are using 6 total Blades. If you plan on building a bigger Turbine, you will need to increase the width of the Turbine depending on how many Blades you plan on using."
 				""
 				"The &9Rotational Complex&r must be placed at the top of the Turbine Rotor. This is then surrounded by &ePressure Dispersers&r."
 				""
@@ -1855,7 +1855,7 @@
 				"05D20B506213A449"
 			]
 			description: [
-				"If you've built the Turbine properly, you will see red particles around the structure. Right clicking on the Turbine will open up the interface."
+				"If you've built the Turbine properly, you will see red particles around the structure. Right-clicking on the Turbine will open up the interface."
 				""
 				"This will tell you all of the information that you need to know, including the total Steam Flow Rate, as well as the total Steam inside of the Turbine."
 				""

--- a/config/ftbquests/quests/chapters/mystical_ag.snbt
+++ b/config/ftbquests/quests/chapters/mystical_ag.snbt
@@ -1983,7 +1983,8 @@
 		{
 			dependencies: ["1CC4F8570A7A99EB"]
 			description: [
-				"The &aWatering Can&r is used to increase the speed that crops grow. Higher tiers have a larger area of effect. To use this, fill it up with some water by right clicking some water, then hold right click near your crops to water them!"
+				"The &aWatering Can&r is used to increase the speed that crops grow. Higher tiers have a larger area of effect.
+				To use this, fill it up with some water by right-clicking some water, then hold right-click near your crops to water them!"
 				""
 				"Tip: You can shift-right click while looking in the air with the watering can to enable auto-watering."
 			]

--- a/config/ftbquests/quests/chapters/powah.snbt
+++ b/config/ftbquests/quests/chapters/powah.snbt
@@ -554,7 +554,7 @@
 				""
 				"The &9Energizing Orb&r will energize items using nearby &aEnergizing Rods&r within a 9x9 area around it, creating better materials for you to use to progress through the &eTiers&r in Powah."
 				""
-				"To power the orb, you'll need to attach Energizing Rods to energy cables that are being supplied with energy. If you want the Orb to energize faster, either make more rods, upgrade to higher tier rods, or both! To see if the Rods are connected, set your &aWrench&r to link mode and you can link any Rod to the Orb."
+				"To power the orb, you'll need to attach Energizing Rods to energy cables that are being supplied with energy. If you want the Orb to energize faster, either make more rods, upgrade to higher-tier rods, or both! To see if the Rods are connected, set your &aWrench&r to link mode and you can link any Rod to the Orb."
 				""
 				"{image:atm:textures/questpics/powah/powah_energizing.png width:200 height:200 align:1}"
 			]
@@ -1018,7 +1018,7 @@
 		{
 			x: -3.0d
 			y: 11.5d
-			description: ["The &5Ender Cell&r will store power for a channel in your &7Ender Network&r. To increase the power capacity of the network, right click on the Ender Cell to open up the interface, then add either a &aBattery&r or an &9Energy Cell&r to increase the overall capacity."]
+			description: ["The &5Ender Cell&r will store power for a channel in your &7Ender Network&r. To increase the power capacity of the network, right-click on the Ender Cell to open up the interface, then add either a &aBattery&r or an &9Energy Cell&r to increase the overall capacity."]
 			hide_dependency_lines: true
 			dependencies: [
 				"78202A1CF5D86B94"

--- a/config/ftbquests/quests/chapters/refined_storage.snbt
+++ b/config/ftbquests/quests/chapters/refined_storage.snbt
@@ -1438,7 +1438,7 @@
 			y: -1.0d
 			shape: "rsquare"
 			description: [
-				"It's time to create the \"Hard Drives\" of Refined Storage. To do this, we'll need a &9Storage Housing&r that we'll combine with a &aStorage Part&r to create a &dStorage Disk&r. Just simply make the desired size of part, then combine with the housing to create a disk."
+				"It's time to create the \"Hard Drives\" of Refined Storage. To do this, we'll need a &9Storage Housing&r that we'll combine with a &aStorage Part&r to create a &dStorage Disk&r. Just simply make the desired size of the part, then combine it with the housing to create a disk."
 				""
 				"The Storage Disk is used to store your items virtually once placed inside of the Disk Drive. It has to be put in a Disk Drive. The Storage Disk won’t despawn when dropped in the world."
 			]
@@ -1477,7 +1477,7 @@
 				""
 				"&9Transmitters&r should be connected to your main system, wherever your Controller is."
 				""
-				"The &9Receiver&r should go wherever you want your external network to be. For exmample, this can be a separate part of your base where you have Bees, a mob farm, etc."
+				"The &9Receiver&r should go wherever you want your external network to be. For example, this can be a separate part of your base where you have Bees, a mob farm, etc."
 				""
 				"To connect the Receiver to your main network, you'll need to use a &eNetwork Card&r. To bind the Network Card, right-click on the Network Receiver, and then place the Network Card into the Network Transmitter that is attached to your main system."
 			]
@@ -1649,7 +1649,7 @@
 				""
 				"Whatever items end up in the block will be stored inside whenever you break it as well."
 				""
-				"If you want to uncraft it, you can sneak right click while holding it."
+				"If you want to un-craft it, you can sneak right-click while holding it."
 			]
 			dependencies: [
 				"4B81E84CAE814BA9"
@@ -1828,7 +1828,7 @@
 			description: [
 				"Allows you to access every part of your RS system."
 				""
-				"This is the All-In-One Wireless Terminal. It allows you to use the crafting grid, fluid grid, and check on your autocrafting all in one place."
+				"This is the All-In-One Wireless Terminal. It allows you to use the crafting grid, the fluid grid, and check on your auto-crafting all in one place."
 			]
 			dependencies: ["15ECBC8E174FA39B"]
 			id: "34DB6863E6CF1B70"
@@ -1852,7 +1852,7 @@
 			x: -8.5d
 			y: -6.0d
 			description: [
-				"The &9Regulator Upgrade&r allows you to maintain a certain amount of items within a block or machine. A great example of this is telling your network that you want to keep 64 Coal within a Furnace. You'd place the upgrade in the exporter attached to the furnace, and set it to 64. Your system will then try to keep the furnace full of fuel!"
+				"The &9Regulator Upgrade&r allows you to maintain a certain amount of items within a block or machine. A great example of this is telling your network that you want to keep 64 Coal within a Furnace. You'd place the upgrade in the exporter attached to the furnace and set it to 64. Your system will then try to keep the furnace full of fuel!"
 				""
 				"But what if you need an item that is crafted? The &9Crafting Upgrade&r does exactly this. If you have the recipe learned inside of a crafter, adding this upgrade to an interface will let it know to craft it if you run out."
 				""

--- a/config/ftbquests/quests/chapters/silent_gear.snbt
+++ b/config/ftbquests/quests/chapters/silent_gear.snbt
@@ -856,7 +856,7 @@
 			description: [
 				"The tip upgrade is used to increase the mining level of the tool."
 				""
-				"For example: If you have an iron pickaxe with 1 diamond, you can make a Diamond Tip Upgrade, and place it on your pickaxe. This will allow it to mine obsidian, as well as giving it a stat boost."
+				"For example: If you have an iron pickaxe with 1 diamond, you can make a Diamond Tip Upgrade, and place it on your pickaxe. This will allow it to mine obsidian, as well as give it a stat boost."
 			]
 			dependencies: ["657B3116A6419420"]
 			id: "158B24939A269D83"
@@ -1261,7 +1261,7 @@
 				""
 				"To create a full pickaxe, you can either add a stick to the crafting table, or create your own custom handle using a &9Tool Rod Template&r instead of using a stick."
 				""
-				"*Note: You can always search up the templates and then pressing U on it, then navigate to the \"Gear Crafting\" tab. This will show you how to make gear parts."
+				"*Note: You can always search up the templates and then press U on it, then navigate to the \"Gear Crafting\" tab. This will show you how to make gear parts."
 			]
 			dependencies: ["7B690431CF1B87D0"]
 			id: "15DE3BF0CBD8E0B4"

--- a/config/ftbquests/quests/chapters/storage.snbt
+++ b/config/ftbquests/quests/chapters/storage.snbt
@@ -313,7 +313,7 @@
 			description: [
 				"Chests that work across dimensions."
 				""
-				"Can be color coded for security! (Right click on the block with the desired dye)."
+				"Can be color-coded for security! (Right-click on the block with the desired dye)."
 				""
 				"*Note: If someone else uses your color combination, they can get the contents!"
 			]
@@ -495,7 +495,7 @@
 				""
 				"This works just like an Ender Chest, but for Drawers."
 				""
-				"To link, Right click the first Ender Drawer with the &aLinking Tool&r, then left click the second Ender Drawer to sync."
+				"To link, Right-click the first Ender Drawer with the &aLinking Tool&r, then left-click the second Ender Drawer to sync."
 			]
 			dependencies: ["072FBEB0F6F1BC48"]
 			id: "1A4B1CA7EC15348E"
@@ -659,7 +659,7 @@
 			x: -9.0d
 			y: 6.5d
 			shape: "circle"
-			subtitle: "Allows the backpack to pickup items."
+			subtitle: "Allows the backpack to pick up items."
 			hide_dependency_lines: true
 			dependencies: ["1FE052F643401232"]
 			hide: true
@@ -1549,7 +1549,7 @@
 			description: [
 				"Used to link Drawers to a controller and to link up Ender Drawers."
 				""
-				"To link Drawers to the Controller, right click the Controller block to start configuration. Right clicking Drawers will add them to the network."
+				"To link Drawers to the Controller, righ--click the Controller block to start configuration. Right-clicking Drawers will add them to the network."
 				""
 				"Holding the tool will show you what Drawers are connected to the Controller."
 			]

--- a/config/ftbquests/quests/chapters/twilight_forest.snbt
+++ b/config/ftbquests/quests/chapters/twilight_forest.snbt
@@ -70,7 +70,7 @@
 			description: [
 				"In the Twilight Forest, there are a bunch of new entities to discover."
 				""
-				"One of the worst is the Cicada. I suggest on killing this for the achievement, but killing any Twilight Forest mob will work."
+				"One of the worst is the Cicada. I suggest killing this for the achievement, but killing any Twilight Forest mob will work."
 			]
 			dependencies: ["4193303999597249"]
 			hide: true
@@ -447,7 +447,7 @@
 			description: [
 				"Inside the Dark Forest, you'll find a structure that leads underground."
 				""
-				"To enter, you'll need to place one of the trophies you've acquired on the nearby pedastal."
+				"To enter, you'll need to place one of the trophies you've acquired on the nearby pedestal."
 				""
 				"On the 3rd layer, you'll find the Knight Phantoms. Defeat these to unlock the next boss."
 				""
@@ -482,7 +482,7 @@
 				""
 				"To enter, look for the reappearing blocks at the base. Find your way through the maze all the way to the final floor to fight the Ur-Ghast."
 				""
-				"The Ur-Ghast is recommended to kill with a ranged weapon. There are 4 Ghast traps found on boss floor, which can be used to damage the Ur-Ghast."
+				"The Ur-Ghast is recommended to kill with a ranged weapon. There are 4 Ghast traps found on the boss floor, which can be used to damage the Ur-Ghast."
 				""
 				"These are charged with Ghastling kills, then activating with redstone. You don't have to use them, but they can prove useful."
 			]
@@ -561,7 +561,7 @@
 				""
 				"At the top of the Aurora Palace, the Snow Queen will summon ice crystals to protect herself."
 				""
-				"She'll also slam ice blocks down that destroys the floor and deals massive damage."
+				"She'll also slam ice blocks down that destroy the floor and deal massive damage."
 				""
 				"You'll only be able to hit her top half, as she's protected by ice blocks."
 				""
@@ -922,7 +922,7 @@
 			x: -4.0d
 			y: -1.5d
 			description: [
-				"This map is a must have for the Twlight Forest."
+				"This map is a must-have for the Twilight Forest."
 				""
 				"Using a Blank Magic Map will give you a map that shows icons for nearby bosses and structures."
 			]
@@ -1398,7 +1398,7 @@
 			x: -2.0d
 			y: 0.10000000000000003d
 			shape: "diamond"
-			description: ["This item will prevent you from losing the items in your main and off hand, as well as your armor when you die."]
+			description: ["This item will prevent you from losing the items in your main and off-hand, as well as your armor when you die."]
 			dependencies: ["4B95D48D7525FFAD"]
 			id: "610F9E9D0B5131C7"
 			tasks: [{

--- a/config/ftbquests/quests/chapters/welcome.snbt
+++ b/config/ftbquests/quests/chapters/welcome.snbt
@@ -397,7 +397,7 @@
 			description: [
 				"To claim chunks, the default key to open the Claim Map is &6M&r."
 				""
-				"To claim a chunk, left click and drag to claim. "
+				"To claim a chunk, left-click and drag to claim. "
 				""
 				"To force load a chunk, shift-left click the chunk. If done properly, you'll see lines across the chunk."
 			]


### PR DESCRIPTION
I fixed some typos and grammar in quests.

I noticed that Applied Energistics 2 quests are in British English while all other quests are written in American English (colour/color). I left it as is for now, although I think it's better to make this consistent.

Note that I also changed "right clicking" to "right-clicking" and similar. Although the version with a dash is grammatically correct (and with a dash it rolls more off the tongue when reading), I can change it back if you don't like it.