### PR TITLE
Enable Computercraft HTTP by default

### DIFF
--- a/config/serverconfigupdater-common.toml
+++ b/config/serverconfigupdater-common.toml
@@ -2,7 +2,7 @@
 ["Version Configuration"]
 	# Define a version here. On world load the mod will look up the serverconfig version and reset all files that specified up to the newest version.
 	# Example: ["1=minecraft","2=forge"] will reset minecraft and forge config on first load, but will only reset forge if the world has been loaded before with only version 1 defined
-	versions = ["1=sophisticatedbackpacks,sophisticatedstorage"]
+	versions = ["1=sophisticatedbackpacks,sophisticatedstorage", "2=computercraft"]
 
 ["File Deleter"]
 	# This is intended for deleting files for pack updates. This is a last resort! Replace with empty files instead when possible. The file will be deleted every launch if it exists! Specify the path to the file. Comma Separated List. Example: scripts/badscript.zs

--- a/defaultconfigs/computercraft-server.toml
+++ b/defaultconfigs/computercraft-server.toml
@@ -33,7 +33,7 @@ command_require_creative = true
 #Controls the HTTP API
 [http]
 	#Enable the "http" API on Computers (see "rules" for more fine grained control than this).
-	enabled = false
+	enabled = true
 	#Enable use of http websockets. This requires the "http_enable" option to also be true.
 	websocket_enabled = false
 	#The number of http requests a computer can make at one time. Additional requests will be queued, and sent when the running requests have finished. Set to 0 for unlimited.


### PR DESCRIPTION
Changed the computercraft default config to enable HTTP by default.

Fixes #1735

TODO:

- [x] Update the default config
- [x] Update the auto-config sync to enable this on the next update