### PR TITLE
#1793 fix cretive jetpack quest

### DIFF
--- a/config/ftbquests/quests/chapters/creative.snbt
+++ b/config/ftbquests/quests/chapters/creative.snbt
@@ -282,6 +282,7 @@
 						Throttle: 1.0d
 					}
 				}
+				match_nbt: true
 				type: "item"
 			}]
 			x: 0.0d


### PR DESCRIPTION
Issue:
- https://github.com/AllTheMods/ATM-8/issues/1793

Solution:
- Add `match_nbt` to creative jetpack quest
