### PR TITLE
Typo in "Visit Mercury"

### DIFF
--- a/config/ftbquests/quests/chapters/ad_astra.snbt
+++ b/config/ftbquests/quests/chapters/ad_astra.snbt
@@ -417,7 +417,7 @@
 				id: "7302AF42EB62C1D2"
 				type: "advancement"
 			}]
-			title: "Visit Mecury"
+			title: "Visit Mercury"
 			x: 1.0d
 			y: 8.0d
 		}


### PR DESCRIPTION
There is typo in Ad Astra quest line. "Visit Mecury" instead of "Visit Mercury"